### PR TITLE
Do not run docker push pipeline on PRs

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -14,13 +14,10 @@
 # OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 # PERFORMANCE OF THIS SOFTWARE.
 
-name: Docker Build
+name: Docker Push Pipeline
 
 on:
   push:
-    branches:
-      - "main"
-  pull_request:
     branches:
       - "main"
 jobs:


### PR DESCRIPTION
Changes the GitHub workflow that builds and pushes images to the docker registry to not run it when pull requests are open.