### PR TITLE
Disable ncurses for oksh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM debian:buster-slim AS builder
     ARG TARGETS
 
     # Build
-    RUN sh "/shvr/shvr.sh" build $TARGETS
+    RUN bash "/shvr/shvr.sh" build $TARGETS
 
 FROM debian:buster-slim
 

--- a/variants/oksh.sh
+++ b/variants/oksh.sh
@@ -47,6 +47,7 @@ shvr_build_oksh ()
 	cd "${build_srcdir}"
 
 	./configure \
+		--disable-curses \
 		--prefix="${SHVR_DIR_OUT}/oksh_$version"
 
 	make -j "$(nproc)"


### PR DESCRIPTION
When moving all builds to a single Docker stage, the shells started to build all in the same machine, causing oksh to be linked against ncurses.

Since the build stage is different from the final image, ncurses was missing and causing oksh binaries to fail invokation.

This change disables linking against ncurses during build, fixing the issue.

Our goal is not to provide interactive shells for personal use, so lacking ncurses still results in a perfectly good oksh.