### PR TITLE
Support bash 2.05b

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -41,6 +41,7 @@ jobs:
             can_fail_build: false
             tags: alganet/shell-versions:test
             targets: >
+              bash_2.05b.13
               bash_3.0.22
               bash_3.1.23
               bash_3.2.57

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -67,6 +67,7 @@ jobs:
             can_fail_build: false
             tags: alganet/shell-versions:all
             targets: >
+              bash_2.05b.13
               bash_3.0.22
               bash_3.1.23
               bash_3.2.57

--- a/variants/bash.sh
+++ b/variants/bash.sh
@@ -26,6 +26,7 @@ shvr_targets_bash ()
 		bash_3.2.57
 		bash_3.1.23
 		bash_3.0.22
+		bash_2.05b.13
 	@
 }
 
@@ -56,6 +57,9 @@ shvr_build_bash ()
 	elif test "$version_baseline" = "3.0"
 	then apt-get -y install \
 			wget patch gcc bison make ncurses-dev
+	elif test "$version_baseline" = "2.05b"
+	then apt-get -y install \
+			wget patch gcc bison make autoconf
 	else apt-get -y install \
 			wget patch gcc bison make
 	fi
@@ -83,11 +87,22 @@ shvr_build_bash ()
 	
 	cd "${build_srcdir}"
 
-	./configure \
-		--prefix="${SHVR_DIR_OUT}/bash_${version}"
+	if test "$version_baseline" = "2.05b"
+	then
+		rm configure
+		autoconf
+		./configure \
+			--prefix="${SHVR_DIR_OUT}/bash_${version}" \
+			--without-bash-malloc
 
-	make -j "$(nproc)"
+		make -j1
+	else
 
+		./configure \
+			--prefix="${SHVR_DIR_OUT}/bash_${version}" \
+
+		make -j "$(nproc)"
+	fi
 	mkdir -p "${SHVR_DIR_OUT}/bash_${version}/bin"
 	cp bash "${SHVR_DIR_OUT}/bash_${version}/bin/bash"
 


### PR DESCRIPTION
The old bash 2.05b is not used in typical production machines, but it is common amongst bootstrapping tools and it is considered the oldest shell with modern features.

Although we currently prefer using package-provided configure scripts, even when autoconf is available, this was not possible for bash 2.05b, which required a regenerated configure script.