### PR TITLE
Add rust shells: yash-rs and brush

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -54,6 +54,10 @@ jobs:
               bash_5.1.16
               bash_5.2.37
               bash_5.3-rc1
+              brush_0.2.19
+              brush_0.2.18
+              brush_0.2.17
+              brush_0.2.16
               busybox_1.21.1
               busybox_1.22.1
               busybox_1.23.2
@@ -179,6 +183,10 @@ jobs:
               yash_2.55
               yash_2.58.1
               yash_2.59
+              yashrs_0.4.2
+              yashrs_0.4.1
+              yashrs_0.4.0
+              yashrs_0.3.0
               zsh_4.2.7
               zsh_5.0.8
               zsh_5.1.1

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -43,6 +43,8 @@ jobs:
             targets: >
               bash_5.1.16
               bash_5.2.37
+              brush_0.2.19
+              brush_0.2.18
               busybox_1.36.1
               busybox_1.37.0
               dash_0.5.11.5
@@ -61,6 +63,8 @@ jobs:
               posh_0.14.1
               yash_2.59
               yash_2.58.1
+              yashrs_0.4.2
+              yashrs_0.4.1
               zsh_5.8.1
               zsh_5.9
           - name: all
@@ -80,6 +84,10 @@ jobs:
               bash_5.1.16
               bash_5.2.37
               bash_5.3-rc1
+              brush_0.2.19
+              brush_0.2.18
+              brush_0.2.17
+              brush_0.2.16
               busybox_1.21.1
               busybox_1.22.1
               busybox_1.23.2
@@ -207,6 +215,10 @@ jobs:
               yash_2.57
               yash_2.58.1
               yash_2.59
+              yashrs_0.4.2
+              yashrs_0.4.1
+              yashrs_0.4.0
+              yashrs_0.3.0
               zsh_4.2.7
               zsh_5.0.8
               zsh_5.1.1

--- a/variants/brush.sh
+++ b/variants/brush.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env sh
+
+# Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+# SPDX-License-Identifier: ISC
+
+shvr_current_brush ()
+{
+	cat <<-@
+		brush_0.2.19
+		brush_0.2.18
+	@
+}
+
+shvr_targets_brush ()
+{
+	cat <<-@
+		brush_0.2.19
+		brush_0.2.18
+		brush_0.2.17
+		brush_0.2.16
+	@
+}
+
+shvr_build_brush ()
+{
+	version="$1"
+	build_srcdir="${SHVR_DIR_SRC}/brush/${version}"
+	mkdir -p "${build_srcdir}"
+	
+	apt-get -y install \
+		curl wget gcc
+    
+	if ! test -f "$HOME/.cargo/env"
+	then
+		curl -o "$HOME/rustup.sh" --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs
+		cd $HOME
+		sh rustup.sh -y
+	fi
+
+	. "$HOME/.cargo/env"
+
+	wget -O "${build_srcdir}.tar.gz" \
+		"https://github.com/reubeno/brush/archive/refs/tags/brush-shell-v${version}.tar.gz"
+
+	tar --extract \
+		--file="${build_srcdir}.tar.gz" \
+		--strip-components=1 \
+		--directory="${build_srcdir}"
+
+	cd "${build_srcdir}"
+
+	cargo build --release
+
+	mkdir -p "${SHVR_DIR_OUT}/brush_${version}/bin"
+	cp "./target/release/brush" "${SHVR_DIR_OUT}/brush_$version/bin"
+	
+	"${SHVR_DIR_OUT}/brush_${version}/bin/brush" -c "echo brush version $version"
+}

--- a/variants/yashrs.sh
+++ b/variants/yashrs.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env sh
+
+# Copyright (c) Alexandre Gomes Gaigalas <alganet@gmail.com>
+# SPDX-License-Identifier: ISC
+
+shvr_current_yashrs ()
+{
+	cat <<-@
+		yashrs_0.4.2
+		yashrs_0.4.1
+	@
+}
+
+shvr_targets_yashrs ()
+{
+	cat <<-@
+		yashrs_0.4.2
+		yashrs_0.4.1
+		yashrs_0.4.0
+		yashrs_0.3.0
+	@
+}
+
+shvr_build_yashrs ()
+{
+	version="$1"
+	build_srcdir="${SHVR_DIR_SRC}/yashrs/${version}"
+	mkdir -p "${build_srcdir}"
+	
+	apt-get -y install \
+		curl wget gcc
+    
+	if ! test -f "$HOME/.cargo/env"
+	then
+		curl -o "$HOME/rustup.sh" --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs
+		cd $HOME
+		sh rustup.sh -y
+	fi
+
+	. "$HOME/.cargo/env"
+
+	wget -O "${build_srcdir}.tar.gz" \
+		"https://github.com/magicant/yash-rs/archive/refs/tags/yash-cli-${version}.tar.gz"
+
+	tar --extract \
+		--file="${build_srcdir}.tar.gz" \
+		--strip-components=1 \
+		--directory="${build_srcdir}"
+
+	cd "${build_srcdir}"
+
+	cargo build --release
+
+	mkdir -p "${SHVR_DIR_OUT}/yashrs_${version}/bin"
+	cp "./target/release/yash3" "${SHVR_DIR_OUT}/yashrs_$version/bin"
+	
+	"${SHVR_DIR_OUT}/yashrs_${version}/bin/yash3" -c "echo yashrs version $version"
+}


### PR DESCRIPTION
These shells have achieved some significant compatibility with more estabilished interpreters and are being included in the build.

Although rust yash is made by the same author and the binary is named yash3, we decided to keep it separately from the already existing yash shell due to version numbering differences and being a completely new codebase.