### PR TITLE
Refresh ksh versions

### DIFF
--- a/.github/actions/downloads/action.yml
+++ b/.github/actions/downloads/action.yml
@@ -235,34 +235,6 @@ runs:
     - uses: ./.github/actions/single-download
       with:
         shvr_shell: ksh
-        shvr_version: "shvrChistory-b_2004-10-11"
-    - uses: ./.github/actions/single-download
-      with:
-        shvr_shell: ksh
-        shvr_version: "shvrChistory-b_2005-02-02"
-    - uses: ./.github/actions/single-download
-      with:
-        shvr_shell: ksh
-        shvr_version: "shvrChistory-b_2005-06-01"
-    - uses: ./.github/actions/single-download
-      with:
-        shvr_shell: ksh
-        shvr_version: "shvrChistory-b_2005-09-16"
-    - uses: ./.github/actions/single-download
-      with:
-        shvr_shell: ksh
-        shvr_version: "shvrChistory-b_2006-02-14"
-    - uses: ./.github/actions/single-download
-      with:
-        shvr_shell: ksh
-        shvr_version: "shvrChistory-b_2006-07-24"
-    - uses: ./.github/actions/single-download
-      with:
-        shvr_shell: ksh
-        shvr_version: "shvrChistory-b_2006-11-15"
-    - uses: ./.github/actions/single-download
-      with:
-        shvr_shell: ksh
         shvr_version: "shvrChistory-b_2007-01-11"
     - uses: ./.github/actions/single-download
       with:

--- a/.github/workflows/docker-all.yml
+++ b/.github/workflows/docker-all.yml
@@ -9,13 +9,11 @@ on:
       - "main"
 jobs:
   download:
-    if: false # Disable job execution
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/downloads
   build:
-    if: false # Disable job execution
     needs: download
     runs-on: ubuntu-24.04
     continue-on-error: ${{ matrix.can_fail_build }}
@@ -103,13 +101,6 @@ jobs:
               ksh_shvrA93uplusm-v1.0.9
               ksh_shvrA93uplusm-v1.0.10
               ksh_shvrB2020-2020.0.0
-              ksh_shvrChistory-b_2004-10-11
-              ksh_shvrChistory-b_2005-02-02
-              ksh_shvrChistory-b_2005-06-01
-              ksh_shvrChistory-b_2005-09-16
-              ksh_shvrChistory-b_2006-02-14
-              ksh_shvrChistory-b_2006-07-24
-              ksh_shvrChistory-b_2006-11-15
               ksh_shvrChistory-b_2007-01-11
               ksh_shvrChistory-b_2008-02-02
               ksh_shvrChistory-b_2008-06-08

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -49,29 +49,162 @@ jobs:
             tags: alganet/shell-versions:test
             # AUTO-GENERATED LIST. DO NOT EDIT MANUALLY.
             targets: >
+              bash_2.05b.13
+              bash_3.0.22
+              bash_3.1.23
+              bash_3.2.57
+              bash_4.0.44
+              bash_4.1.17
+              bash_4.2.53
+              bash_4.3.48
+              bash_4.4.23
+              bash_5.0.18
+              bash_5.1.16
               bash_5.2.37
               bash_5.3
+              brush_0.2.20
+              brush_0.2.21
               brush_0.2.22
               brush_0.2.23
+              busybox_1.21.1
+              busybox_1.22.1
+              busybox_1.23.2
+              busybox_1.24.2
+              busybox_1.25.1
+              busybox_1.26.2
+              busybox_1.27.2
+              busybox_1.28.4
+              busybox_1.29.3
+              busybox_1.30.1
+              busybox_1.31.1
+              busybox_1.32.1
+              busybox_1.33.2
+              busybox_1.34.1
+              busybox_1.35.0
               busybox_1.36.1
               busybox_1.37.0
+              dash_0.5.5.1
+              dash_0.5.6.1
+              dash_0.5.7
+              dash_0.5.8
+              dash_0.5.9.1
+              dash_0.5.10.2
+              dash_0.5.11.5
               dash_0.5.12
               dash_0.5.13
+              ksh_shvrA93uplusm-v1.0.1
+              ksh_shvrA93uplusm-v1.0.2
+              ksh_shvrA93uplusm-v1.0.3
+              ksh_shvrA93uplusm-v1.0.4
+              ksh_shvrA93uplusm-v1.0.6
+              ksh_shvrA93uplusm-v1.0.7
+              ksh_shvrA93uplusm-v1.0.8
               ksh_shvrA93uplusm-v1.0.9
               ksh_shvrA93uplusm-v1.0.10
+              ksh_shvrB2020-2020.0.0
+              ksh_shvrChistory-b_2007-01-11
+              ksh_shvrChistory-b_2008-02-02
+              ksh_shvrChistory-b_2008-06-08
+              ksh_shvrChistory-b_2008-11-04
+              ksh_shvrChistory-b_2010-06-21
+              ksh_shvrChistory-b_2010-10-26
+              ksh_shvrChistory-b_2011-03-10
+              ksh_shvrChistory-b_2012-08-01
+              ksh_shvrChistory-b_2016-01-10
+              loksh_6.7.5
+              loksh_6.8.1
+              loksh_6.9
+              loksh_7.0
+              loksh_7.1
+              loksh_7.3
+              loksh_7.4
+              loksh_7.5
+              loksh_7.6
               loksh_7.7
               loksh_7.8
+              mksh_R45
+              mksh_R46
+              mksh_R47
+              mksh_R48b
+              mksh_R49
+              mksh_R50f
+              mksh_R51
+              mksh_R52c
+              mksh_R53a
+              mksh_R54
+              mksh_R55
+              mksh_R56c
+              mksh_R57
               mksh_R58
               mksh_R59c
+              oksh_6.5
+              oksh_6.6
+              oksh_6.7.1
+              oksh_6.8.1
+              oksh_6.9
+              oksh_7.0
+              oksh_7.1
+              oksh_7.2
+              oksh_7.3
+              oksh_7.4
+              oksh_7.5
+              oksh_7.6
               oksh_7.7
               oksh_7.8
+              osh_0.25.0
+              osh_0.26.0
+              osh_0.27.0
+              osh_0.28.0
+              osh_0.29.0
+              osh_0.30.0
+              osh_0.31.0
+              osh_0.32.0
+              osh_0.33.0
+              osh_0.34.0
               osh_0.35.0
               osh_0.36.0
+              posh_0.12.6
               posh_0.13.2
               posh_0.14.1
+              yashrs_0.3.0
+              yashrs_0.4.0
+              yashrs_0.4.1
+              yashrs_0.4.2
+              yashrs_0.4.3
+              yashrs_0.4.4
               yashrs_0.4.5
+              yashrs_3.0.0
+              yashrs_3.0.1
+              yashrs_3.0.2
               yashrs_3.0.3
+              yash_2.41
+              yash_2.42
+              yash_2.43
+              yash_2.44
+              yash_2.45
+              yash_2.46
+              yash_2.47
+              yash_2.48
+              yash_2.49
+              yash_2.50
+              yash_2.51
+              yash_2.52
+              yash_2.53
+              yash_2.54
+              yash_2.55
+              yash_2.56.1
+              yash_2.57
+              yash_2.58.1
               yash_2.59
               yash_2.60
+              zsh_4.2.7
+              zsh_5.0.8
+              zsh_5.1.1
+              zsh_5.2
+              zsh_5.3.1
+              zsh_5.4.2
+              zsh_5.5.1
+              zsh_5.6.2
+              zsh_5.7.1
               zsh_5.8.1
               zsh_5.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ FROM debian:bookworm-slim AS builder
     # Copy contents
     COPY "shvr.sh" "/shvr/shvr.sh"
     COPY "variants/" "/shvr/variants"
+    COPY "patches/" "/shvr/patches"
     COPY "build/" "/usr/src/shvr"
     RUN chmod +x "/shvr/shvr.sh"
 

--- a/patches/ksh/shvrChistory-b_2007-01-11/001-Mamfile.diff
+++ b/patches/ksh/shvrChistory-b_2007-01-11/001-Mamfile.diff
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+# SPDX-License-Identifier: ISC
+--- src/cmd/ksh93/Mamfile
++++ src/cmd/ksh93/Mamfile
+@@ -1193,7 +1193,7 @@
+ prev +li
+ prev ${mam_libsecdb}
+ prev +lintl
+-exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} '  ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcmd} ${mam_libast} ${mam_libm} ${mam_libdl}  : run features/math.sh data/math.tab
++exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} '  ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcmd} ${mam_libast} -lm ${mam_libm} ${mam_libdl}  : run features/math.sh data/math.tab
+ make ${PACKAGE_ast_INCLUDE}/ast_standards.h implicit
+ done ${PACKAGE_ast_INCLUDE}/ast_standards.h dontcare
+ done FEATURE/math generated
+@@ -1348,7 +1348,7 @@
+ prev +li
+ prev ${mam_libsecdb}
+ prev +lintl
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib}  -o ksh pmain.o -lm ${mam_libshell} ${mam_libdl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib}  -o ksh pmain.o ${mam_libshell} ${mam_libdl} ${mam_libast} -lm
+ done ksh generated
+ make shcomp
+ make shcomp.o
+@@ -1371,7 +1371,7 @@
+ prev +lintl
+ setv CC.DLL -UCC.DLL
+ setv SH_DICT -DSH_DICT="\"libshell\""
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib}  -o shcomp shcomp.o -lm ${mam_libshell} ${mam_libdl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib}  -o shcomp shcomp.o ${mam_libshell} ${mam_libdl} ${mam_libast} -lm
+ done shcomp generated
+ make suid_exec
+ make suid_exec.o
+@@ -1394,7 +1394,7 @@
+ prev ${mam_libsecdb}
+ prev +lintl
+ setv CC.DLL -UCC.DLL
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib}  -o suid_exec suid_exec.o ${mam_libast} ${mam_libdl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib}  -o suid_exec suid_exec.o ${mam_libast} ${mam_libdl} ${mam_libast} -lm
+ done suid_exec generated
+ make shell
+ prev libshell.a archive

--- a/patches/ksh/shvrChistory-b_2008-02-02/001-Mamfile.diff
+++ b/patches/ksh/shvrChistory-b_2008-02-02/001-Mamfile.diff
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+# SPDX-License-Identifier: ISC
+--- src/cmd/ksh93/Mamfile
++++ src/cmd/ksh93/Mamfile
+@@ -1196,7 +1196,7 @@
+ prev +li
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+-exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} '  ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcmd} ${mam_libast} ${mam_libm} ${mam_libdl} ${mam_libnsl}  : run features/math.sh data/math.tab
++exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} '  ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcmd} ${mam_libast} -lm ${mam_libm} ${mam_libdl} ${mam_libnsl}  : run features/math.sh data/math.tab
+ make ${PACKAGE_ast_INCLUDE}/ast_standards.h implicit
+ done ${PACKAGE_ast_INCLUDE}/ast_standards.h dontcare
+ done FEATURE/math generated
+@@ -1350,7 +1350,7 @@
+ prev +li
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o ksh pmain.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libdl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o ksh pmain.o ${mam_libshell} ${mam_libnsl} ${mam_libdl} ${mam_libast} -lm
+ done ksh generated
+ make shcomp
+ make shcomp.o
+@@ -1374,7 +1374,7 @@
+ prev ${mam_libsecdb}
+ setv CC.DLL -UCC.DLL
+ setv SH_DICT -DSH_DICT="\"libshell\""
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o shcomp shcomp.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libdl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o shcomp shcomp.o ${mam_libshell} ${mam_libnsl} ${mam_libdl} ${mam_libast} -lm
+ done shcomp generated
+ make suid_exec
+ make suid_exec.o
+@@ -1397,7 +1397,7 @@
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+ setv CC.DLL -UCC.DLL
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o suid_exec suid_exec.o ${mam_libast} ${mam_libnsl} ${mam_libdl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o suid_exec suid_exec.o ${mam_libast} ${mam_libnsl} ${mam_libdl} ${mam_libast} -lm
+ done suid_exec generated
+ make shell
+ prev libshell.a archive

--- a/patches/ksh/shvrChistory-b_2008-06-08/001-Mamfile.diff
+++ b/patches/ksh/shvrChistory-b_2008-06-08/001-Mamfile.diff
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+# SPDX-License-Identifier: ISC
+--- src/cmd/ksh93/Mamfile
++++ src/cmd/ksh93/Mamfile
+@@ -1216,7 +1216,7 @@
+ prev +li
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+-exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} '  ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcmd} ${mam_libast} ${mam_libm} ${mam_libdl} ${mam_libnsl}  : run features/math.sh data/math.tab
++exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} '  ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcmd} ${mam_libast} ${mam_libm} -lm ${mam_libdl} ${mam_libnsl} : run features/math.sh data/math.tab
+ make ${PACKAGE_ast_INCLUDE}/ast_standards.h implicit
+ done ${PACKAGE_ast_INCLUDE}/ast_standards.h dontcare
+ done FEATURE/math generated
+@@ -1370,7 +1370,7 @@
+ prev +li
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o ksh pmain.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libdl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o ksh pmain.o ${mam_libshell} ${mam_libnsl} ${mam_libdl} ${mam_libast} -lm
+ done ksh generated
+ make shcomp
+ make shcomp.o
+@@ -1394,7 +1394,7 @@
+ prev ${mam_libsecdb}
+ setv CC.DLL -UCC.DLL
+ setv SH_DICT -DSH_DICT="\"libshell\""
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o shcomp shcomp.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libdl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o shcomp shcomp.o ${mam_libshell} ${mam_libnsl} ${mam_libdl} ${mam_libast} -lm
+ done shcomp generated
+ make suid_exec
+ make suid_exec.o
+@@ -1417,7 +1417,7 @@
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+ setv CC.DLL -UCC.DLL
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o suid_exec suid_exec.o ${mam_libast} ${mam_libnsl} ${mam_libdl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o suid_exec suid_exec.o ${mam_libast} ${mam_libnsl} ${mam_libdl} ${mam_libast} -lm
+ done suid_exec generated
+ make shell
+ prev libshell.a archive

--- a/patches/ksh/shvrChistory-b_2008-11-04/001-Mamfile.diff
+++ b/patches/ksh/shvrChistory-b_2008-11-04/001-Mamfile.diff
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+# SPDX-License-Identifier: ISC
+--- src/cmd/ksh93/Mamfile
++++ src/cmd/ksh93/Mamfile
+@@ -1219,7 +1219,7 @@
+ prev +li
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+-exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} '  ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcmd} ${mam_libast} ${mam_libm} ${mam_libnsl}  : run features/math.sh data/math.tab
++exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} '  ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcmd} ${mam_libast} -lm ${mam_libm} ${mam_libnsl}  : run features/math.sh data/math.tab
+ make ${PACKAGE_ast_INCLUDE}/ast_standards.h implicit
+ done ${PACKAGE_ast_INCLUDE}/ast_standards.h dontcare
+ done FEATURE/math generated
+@@ -1374,7 +1374,7 @@
+ prev +li
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o ksh pmain.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o ksh pmain.o ${mam_libshell} ${mam_libnsl} ${mam_libast} -lm
+ done ksh generated
+ make shcomp
+ make shcomp.o
+@@ -1398,7 +1398,7 @@
+ prev ${mam_libsecdb}
+ setv CC.DLL -UCC.DLL
+ setv SH_DICT -DSH_DICT="\"libshell\""
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o shcomp shcomp.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o shcomp shcomp.o ${mam_libshell} ${mam_libnsl} ${mam_libast} -lm
+ done shcomp generated
+ make suid_exec
+ make suid_exec.o
+@@ -1421,7 +1421,7 @@
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+ setv CC.DLL -UCC.DLL
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o suid_exec suid_exec.o ${mam_libast} ${mam_libnsl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o suid_exec suid_exec.o ${mam_libast} ${mam_libnsl} ${mam_libast} -lm
+ done suid_exec generated
+ make shell
+ prev libshell.a archive

--- a/patches/ksh/shvrChistory-b_2010-06-21/001-Mamfile.diff
+++ b/patches/ksh/shvrChistory-b_2010-06-21/001-Mamfile.diff
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+# SPDX-License-Identifier: ISC
+--- src/cmd/ksh93/Mamfile
++++ src/cmd/ksh93/Mamfile
+@@ -1242,7 +1242,7 @@
+ prev +li
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+-exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} '  ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcmd} ${mam_libast} ${mam_libm} ${mam_libnsl}  : run features/math.sh ${PACKAGEROOT}/src/cmd/ksh93/data/math.tab
++exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} '  ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcmd} ${mam_libast} -lm ${mam_libm} ${mam_libnsl}  : run features/math.sh ${PACKAGEROOT}/src/cmd/ksh93/data/math.tab
+ make ${PACKAGE_ast_INCLUDE}/ast_standards.h implicit
+ done ${PACKAGE_ast_INCLUDE}/ast_standards.h dontcare
+ done FEATURE/math generated
+@@ -1396,7 +1396,7 @@
+ prev +li
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o ksh pmain.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o ksh pmain.o ${mam_libshell} ${mam_libnsl} ${mam_libast} -lm
+ done ksh generated
+ make shcomp
+ make shcomp.o
+@@ -1420,7 +1420,7 @@
+ prev ${mam_libsecdb}
+ setv CC.DLL -UCC.DLL
+ setv SH_DICT -DSH_DICT="\"libshell\""
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o shcomp shcomp.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o shcomp shcomp.o ${mam_libshell} ${mam_libnsl} ${mam_libast} -lm
+ done shcomp generated
+ make suid_exec
+ make suid_exec.o
+@@ -1443,7 +1443,7 @@
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+ setv CC.DLL -UCC.DLL
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o suid_exec suid_exec.o ${mam_libast} ${mam_libnsl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o suid_exec suid_exec.o ${mam_libast} ${mam_libnsl} ${mam_libast} -lm
+ done suid_exec generated
+ make shell
+ prev libshell.a archive

--- a/patches/ksh/shvrChistory-b_2010-10-26/001-Mamfile.diff
+++ b/patches/ksh/shvrChistory-b_2010-10-26/001-Mamfile.diff
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+# SPDX-License-Identifier: ISC
+--- src/cmd/ksh93/Mamfile
++++ src/cmd/ksh93/Mamfile
+@@ -1268,7 +1268,7 @@
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+ prev ${mam_liborder} archive
+-exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} '  ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcoshell} ${mam_libcmd} ${mam_libast} ${mam_libm} ${mam_libnsl}  : run features/math.sh data/math.tab
++exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} '  ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcoshell} ${mam_libcmd} ${mam_libast} -lm ${mam_libm} ${mam_libnsl}  : run features/math.sh data/math.tab
+ make ${PACKAGE_ast_INCLUDE}/ast_standards.h implicit
+ done ${PACKAGE_ast_INCLUDE}/ast_standards.h dontcare
+ done FEATURE/math generated
+@@ -1423,7 +1423,7 @@
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+ prev ${mam_liborder} archive
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o ksh pmain.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o ksh pmain.o ${mam_libshell} ${mam_libnsl} ${mam_libast} -lm
+ done ksh generated
+ make shcomp
+ make shcomp.o
+@@ -1448,7 +1448,7 @@
+ prev ${mam_liborder} archive
+ setv CC.DLL -UCC.DLL
+ setv SH_DICT -DSH_DICT="\"libshell\""
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o shcomp shcomp.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o shcomp shcomp.o ${mam_libshell} ${mam_libnsl} ${mam_libast} -lm
+ done shcomp generated
+ make suid_exec
+ make suid_exec.o
+@@ -1472,7 +1472,7 @@
+ prev ${mam_libsecdb}
+ prev ${mam_liborder} archive
+ setv CC.DLL -UCC.DLL
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o suid_exec suid_exec.o ${mam_libast} ${mam_libnsl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o suid_exec suid_exec.o ${mam_libast} ${mam_libnsl} ${mam_libast} -lm
+ done suid_exec generated
+ make shell
+ prev libshell.a archive

--- a/patches/ksh/shvrChistory-b_2011-03-10/001-Mamfile.diff
+++ b/patches/ksh/shvrChistory-b_2011-03-10/001-Mamfile.diff
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+# SPDX-License-Identifier: ISC
+--- src/cmd/ksh93/Mamfile
++++ src/cmd/ksh93/Mamfile
+@@ -1267,7 +1267,7 @@
+ prev +li
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+-exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} '  ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcoshell} ${mam_libcmd} ${mam_libast} ${mam_libm} ${mam_libnsl}  : run features/math.sh data/math.tab
++exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} '  ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcoshell} ${mam_libcmd} ${mam_libast} -lm ${mam_libm} ${mam_libnsl}  : run features/math.sh data/math.tab
+ make ${PACKAGE_ast_INCLUDE}/ast_standards.h implicit
+ done ${PACKAGE_ast_INCLUDE}/ast_standards.h dontcare
+ done FEATURE/math generated
+@@ -1421,7 +1421,7 @@
+ prev +li
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o ksh pmain.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o ksh pmain.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libast} -lm
+ done ksh generated
+ make shcomp
+ make shcomp.o
+@@ -1445,7 +1445,7 @@
+ prev ${mam_libsecdb}
+ setv CC.DLL -UCC.DLL
+ setv SH_DICT -DSH_DICT="\"libshell\""
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o shcomp shcomp.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o shcomp shcomp.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libast} -lm
+ done shcomp generated
+ make suid_exec
+ make suid_exec.o
+@@ -1468,7 +1468,7 @@
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+ setv CC.DLL -UCC.DLL
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o suid_exec suid_exec.o ${mam_libast} ${mam_libnsl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o suid_exec suid_exec.o ${mam_libast} ${mam_libnsl} ${mam_libast} -lm
+ done suid_exec generated
+ make shell
+ prev libshell.a archive

--- a/patches/ksh/shvrChistory-b_2012-08-01/001-Mamfile.diff
+++ b/patches/ksh/shvrChistory-b_2012-08-01/001-Mamfile.diff
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+# SPDX-License-Identifier: ISC
+--- src/cmd/ksh93/Mamfile
++++ src/cmd/ksh93/Mamfile
+@@ -1188,7 +1188,7 @@
+ make data/math.tab implicit
+ done data/math.tab
+ done features/math.sh dontcare
+-exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} ' ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcoshell} ${mam_libcmd} ${mam_libast} ${mam_libm} ${mam_libnsl} : run features/math.sh ${PACKAGEROOT}/src/cmd/ksh93/data/math.tab
++exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} ' ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcoshell} ${mam_libcmd} ${mam_libast} -lm ${mam_libm} ${mam_libnsl} : run features/math.sh ${PACKAGEROOT}/src/cmd/ksh93/data/math.tab
+ make ${PACKAGE_ast_INCLUDE}/ast_standards.h implicit
+ done ${PACKAGE_ast_INCLUDE}/ast_standards.h dontcare
+ done FEATURE/math generated
+@@ -1337,7 +1337,7 @@
+ prev +li
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o ksh pmain.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o ksh pmain.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libast} -lm
+ done ksh generated
+ make shcomp
+ make shcomp.o
+@@ -1361,7 +1361,7 @@
+ prev ${mam_libsecdb}
+ setv CC.DLL -UCC.DLL
+ setv SH_DICT -DSH_DICT="\"libshell\""
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o shcomp shcomp.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o shcomp shcomp.o -lm ${mam_libshell} ${mam_libnsl} ${mam_libast} -lm
+ done shcomp generated
+ make suid_exec
+ make suid_exec.o
+@@ -1384,7 +1384,7 @@
+ prev ${mam_libsocket}
+ prev ${mam_libsecdb}
+ setv CC.DLL -UCC.DLL
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o suid_exec suid_exec.o ${mam_libast} ${mam_libnsl} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o suid_exec suid_exec.o ${mam_libast} ${mam_libnsl} ${mam_libast} -lm
+ done suid_exec generated
+ make shell
+ prev libshell.a archive

--- a/patches/ksh/shvrChistory-b_2016-01-10/001-Mamfile.diff
+++ b/patches/ksh/shvrChistory-b_2016-01-10/001-Mamfile.diff
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+# SPDX-License-Identifier: ISC
+--- src/cmd/ksh93/Mamfile
++++ src/cmd/ksh93/Mamfile
+@@ -1251,7 +1251,7 @@
+ make data/math.tab implicit
+ done data/math.tab
+ done features/math.sh dontcare
+-exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} ' ref ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcoshell} ${mam_libcmd} ${mam_libast} : run features/math.sh ${PACKAGEROOT}/src/cmd/ksh93/data/math.tab
++exec - iffe -v -c '${CC} ${mam_cc_FLAGS} ${CCFLAGS}   ${LDFLAGS} ' ref ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdll} ${mam_libcoshell} ${mam_libcmd} ${mam_libast} -lm : run features/math.sh ${PACKAGEROOT}/src/cmd/ksh93/data/math.tab
+ make ${PACKAGE_ast_INCLUDE}/ast_standards.h implicit
+ done ${PACKAGE_ast_INCLUDE}/ast_standards.h dontcare
+ done FEATURE/math generated
+@@ -1444,7 +1444,7 @@
+ prev +ljobs
+ prev +li
+ prev ${mam_libsecdb}
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o ksh pmain.o -lm ${mam_libshell} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o ksh pmain.o -lm ${mam_libshell} ${mam_libast} -lm
+ done ksh generated
+ make shcomp
+ make shcomp.o
+@@ -1467,7 +1467,7 @@
+ prev ${mam_libsecdb}
+ setv CC.DLL -UCC.DLL
+ setv SH_DICT -DSH_DICT="\"libshell\""
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o shcomp shcomp.o -lm ${mam_libshell} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o shcomp shcomp.o -lm ${mam_libshell} ${mam_libast} -lm
+ done shcomp generated
+ make suid_exec
+ make suid_exec.o
+@@ -1489,7 +1489,7 @@
+ prev +li
+ prev ${mam_libsecdb}
+ setv CC.DLL -UCC.DLL
+-exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L${INSTALLROOT}/lib} -o suid_exec suid_exec.o ${mam_libast} ${mam_libast}
++exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L${INSTALLROOT}/lib} -o suid_exec suid_exec.o ${mam_libast} ${mam_libast} -lm
+ done suid_exec generated
+ make bash
+ prev ksh

--- a/shvr.sh
+++ b/shvr.sh
@@ -118,7 +118,7 @@ shvr_github_regen_downloads ()
 			shvr_clear_versioninfo
 			interpreter="${1%%_*}"
 			version="${1#*_}"
-			
+
 			cat <<-@ | sed 's/.//'
 				|    - uses: ./.github/actions/single-download
 				|      with:
@@ -127,7 +127,7 @@ shvr_github_regen_downloads ()
 			@
 
 			. "${SHVR_DIR_SELF}/variants/${interpreter}.sh"
-			if 
+			if
 				command -v shvr_versioninfo_"${interpreter}" >/dev/null 2>&1 &&
 				shvr_versioninfo_"${interpreter}" "$version" &&
 				test -n "$version_baseline"
@@ -174,7 +174,7 @@ shvr_github_regen_all ()
 {
 	(shvr_github_regen_downloads)
 	(shvr_github_regen_workflow docker-all targets)
-	(shvr_github_regen_workflow docker-test current)
+	(shvr_github_regen_workflow docker-test targets)
 	(shvr_github_regen_workflow docker-latest current)
 }
 

--- a/variants/ksh.sh
+++ b/variants/ksh.sh
@@ -33,13 +33,6 @@ shvr_targets_ksh ()
 		ksh_shvrChistory-b_2008-06-08
 		ksh_shvrChistory-b_2008-02-02
 		ksh_shvrChistory-b_2007-01-11
-		ksh_shvrChistory-b_2006-11-15
-		ksh_shvrChistory-b_2006-07-24
-		ksh_shvrChistory-b_2006-02-14
-		ksh_shvrChistory-b_2005-09-16
-		ksh_shvrChistory-b_2005-06-01
-		ksh_shvrChistory-b_2005-02-02
-		ksh_shvrChistory-b_2004-10-11
 	@
 }
 
@@ -55,7 +48,7 @@ shvr_download_ksh ()
 	shvr_versioninfo_ksh "$1"
 	build_srcdir="${SHVR_DIR_SRC}/ksh/${version}"
 	mkdir -p "${SHVR_DIR_SRC}/ksh"
-	
+
 	if ! test -f "${build_srcdir}.tar.gz"
 	then
 		case "$fork_name" in
@@ -93,7 +86,7 @@ shvr_build_ksh ()
 			;;
 		*'history')
 			apt-get -y install \
-				wget gcc
+				wget gcc patch
 			;;
 	esac
 
@@ -103,6 +96,13 @@ shvr_build_ksh ()
 		--directory="${build_srcdir}"
 
 	cd "${build_srcdir}"
+
+	if test -d "${SHVR_DIR_SELF}/patches/ksh/$version"
+	then
+		find "${SHVR_DIR_SELF}/patches/ksh/$version" -type f | sort | while read -r patch_file
+		do patch -p0 < "$patch_file"
+		done
+	fi
 
 	if test -f "bin/package"
 	then
@@ -124,6 +124,6 @@ shvr_build_ksh ()
 		cp "build/src/cmd/ksh93/ksh" "${SHVR_DIR_OUT}/ksh_${version}/bin/ksh"
 		cp "build/src/cmd/ksh93/shcomp" "${SHVR_DIR_OUT}/ksh_${version}/bin/shcomp"
 	fi
-	
+
 	"${SHVR_DIR_OUT}/ksh_${version}/bin/ksh" -c "echo ksh version $version"
 }

--- a/variants/mksh.sh
+++ b/variants/mksh.sh
@@ -40,7 +40,7 @@ shvr_download_mksh ()
 
 	if ! test -f "${build_srcdir}.tar.gz"
 	then
-		wget -O "${build_srcdir}.tgz" \
+		wget -O "${build_srcdir}.tar.gz" \
 			"https://github.com/MirBSD/mksh/archive/refs/tags/mksh-$version.tar.gz"
 	fi
 }
@@ -55,7 +55,7 @@ shvr_build_mksh ()
 		wget gcc make
 
 	tar --extract \
-		--file="${build_srcdir}.tgz" \
+		--file="${build_srcdir}.tar.gz" \
 		--strip-components=1 \
 		--directory="${build_srcdir}"
 
@@ -65,6 +65,6 @@ shvr_build_mksh ()
 
 	mkdir -p "${SHVR_DIR_OUT}/mksh_${version}/bin"
 	cp "mksh" "${SHVR_DIR_OUT}/mksh_$version/bin"
-	
+
 	"${SHVR_DIR_OUT}/mksh_${version}/bin/mksh" -c "echo mksh version $version"
 }

--- a/variants/oksh.sh
+++ b/variants/oksh.sh
@@ -67,6 +67,6 @@ shvr_build_oksh ()
 	make -j "$(nproc)"
 	mkdir -p "${SHVR_DIR_OUT}/oksh_${version}/bin"
 	cp "oksh" "${SHVR_DIR_OUT}/oksh_$version/bin"
-	
+
 	"${SHVR_DIR_OUT}/oksh_${version}/bin/oksh" -c "echo oksh version $version"
 }


### PR DESCRIPTION
 - Removed versions before 2007 from the build list.
 - Included patches for `-lm` on newer GCCs for ksh historical versions since 2007.