### PR TITLE
Base final image on busybox, not scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,16 +33,11 @@ FROM debian:bookworm-slim AS builder
     RUN mkdir -p /deps/opt/shvr && \
         find /opt \( -type l -o -type f \) | sort -t'_' -k1,1 -k2Vr > /deps/opt/shvr/manifest.txt
 
-    # Find first shell in TARGETS and symlink it to /deps/bin/sh
-    RUN first_shell=$(echo $TARGETS | cut -d' ' -f1) && \
-        first_shell_opt_path=$(find /opt -type d -name "$first_shell*" | head -n1) && \
-        first_shell_executable=$(find "$first_shell_opt_path" -type f -executable | head -n1) && \
-        ln -s "$first_shell_executable" /deps/bin/sh
 
-FROM scratch
+FROM busybox:stable-musl
 
     # Copy helper script
-    COPY "entrypoint.sh" "entrypoint.sh"
+    COPY "entrypoint.sh" "/opt/shvr/entrypoint.sh"
 
     # Setup environment
     ENV SHVR_DIR_OUT=/opt
@@ -52,4 +47,4 @@ FROM scratch
     COPY --from=builder "$SHVR_DIR_OUT" "$SHVR_DIR_OUT"
     COPY --from=builder /deps /
 
-    ENTRYPOINT [ "/bin/sh", "entrypoint.sh" ]
+    ENTRYPOINT [ "/bin/sh", "/opt/shvr/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Multiple versions of multiple shells. Ideal for testing portable shell scripts.
  - **latest** - Contains the two most recent versions of each shell. Ideal for testing up to date scripts.
  - **all** - Everything we can build in a single image. Ideal for testing legacy and backwards compatible scripts.
 
+Shells are built on debian-slim, and copied during multi-stage to a barebones
+busybox image (you get busybox tools + all shells).
+
 ## Basic Usage
 
 List all shells:
@@ -79,9 +82,6 @@ $ docker run -it --rm "mymultishell"
 ```
 
 You can pass a shorter list of versions instead of the full `$(sh shvr.sh targets)`.
-
-The first shell in the list will be chosen to run the entrypoint.sh file for
-the image.
 
 This is particularly useful if you want to test a version that we don't bundle
 by default, such as an old patch. Our scripts are able to build most


### PR DESCRIPTION
As it turns out, few people will use this image just for the shells, and they need some barebones utils that busybox can provide. This adds almost no overhead.

Additionally, we changed the entrypoint to be less sensible to changing the workdir when running the container.