### PR TITLE
Separate installing deps from building steps more explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ FROM debian:trixie-slim AS builder
     ARG TARGETS
 
     # Build
+    RUN bash "/shvr/shvr.sh" deps $TARGETS
     RUN bash "/shvr/shvr.sh" build $TARGETS
 
     # Extract unique library dependencies

--- a/variants/ash.sh
+++ b/variants/ash.sh
@@ -28,7 +28,6 @@ shvr_download_ash ()
 shvr_build_ash ()
 {
 	shvr_versioninfo_ash "$1"
-	shvr_deps_ash "$1"
 
 	mkdir -p "${build_srcdir}"
 	mkdir -p /usr/src/busybox

--- a/variants/bash.sh
+++ b/variants/bash.sh
@@ -83,8 +83,6 @@ shvr_build_bash ()
 	build_srcdir="${SHVR_DIR_SRC}/bash/${version_baseline}"
 	mkdir -p "${build_srcdir}"
 
-	shvr_deps_bash "$1"
-
 	tar --extract \
 		--file="${build_srcdir}.tar.gz" \
 		--strip-components=1 \

--- a/variants/brush.sh
+++ b/variants/brush.sh
@@ -43,11 +43,11 @@ shvr_download_brush ()
 
 shvr_build_brush ()
 {
+	. "$HOME/.cargo/env"
+
 	shvr_versioninfo_brush "$1"
 
 	mkdir -p "${build_srcdir}"
-
-	shvr_deps_brush "$1"
 
 	tar --extract \
 		--file="${build_srcdir}.tar.gz" \
@@ -56,7 +56,7 @@ shvr_build_brush ()
 
 	cd "${build_srcdir}"
 
-	cargo build --release
+	RUSTFLAGS="-A unused_imports" cargo build --release
 
 	mkdir -p "${SHVR_DIR_OUT}/brush_${version}/bin"
 	cp "./target/release/brush" "${SHVR_DIR_OUT}/brush_$version/bin"
@@ -75,6 +75,4 @@ shvr_deps_brush ()
 		shvr_download_rustup
 		sh "${SHVR_DIR_SRC}/rustup-init-1.28.2.sh" -y
 	fi
-
-	. "$HOME/.cargo/env"
 }

--- a/variants/dash.sh
+++ b/variants/dash.sh
@@ -50,8 +50,6 @@ shvr_build_dash ()
 
 	mkdir -p "${build_srcdir}"
 
-	shvr_deps_dash "$1"
-
 	tar --extract \
 		--file="${build_srcdir}.tar.gz" \
 		--strip-components=1 \

--- a/variants/hush.sh
+++ b/variants/hush.sh
@@ -31,8 +31,6 @@ shvr_build_hush ()
 
 	mkdir -p "${build_srcdir}"
 
-	shvr_deps_hush "$1"
-
 	mkdir -p /usr/src/busybox
 	tar --extract \
 		--file="${build_srcdir}.tar.bz2" \

--- a/variants/ksh.sh
+++ b/variants/ksh.sh
@@ -72,8 +72,6 @@ shvr_build_ksh ()
 
 	mkdir -p "${build_srcdir}"
 
-	shvr_deps_ksh "$1"
-
 	tar --extract \
 		--file="${build_srcdir}.tar.gz" \
 		--strip-components=1 \

--- a/variants/loksh.sh
+++ b/variants/loksh.sh
@@ -52,8 +52,6 @@ shvr_build_loksh ()
 
 	mkdir -p "${build_srcdir}"
 
-	shvr_deps_loksh "$1"
-
 	tar --extract \
 		--file="${build_srcdir}.tar.xz" \
 		--strip-components=1 \

--- a/variants/mksh.sh
+++ b/variants/mksh.sh
@@ -56,8 +56,6 @@ shvr_build_mksh ()
 
 	mkdir -p "${build_srcdir}"
 
-	shvr_deps_mksh "$1"
-
 	tar --extract \
 		--file="${build_srcdir}.tar.gz" \
 		--strip-components=1 \

--- a/variants/oksh.sh
+++ b/variants/oksh.sh
@@ -67,8 +67,6 @@ shvr_build_oksh ()
 
 	mkdir -p "${build_srcdir}"
 
-	shvr_deps_oksh "$1"
-
 	tar --extract \
 		--file="${build_srcdir}.tar.gz" \
 		--strip-components=1 \

--- a/variants/osh.sh
+++ b/variants/osh.sh
@@ -53,8 +53,6 @@ shvr_build_osh ()
 
 	mkdir -p "${build_srcdir}"
 
-	shvr_deps_osh "$1"
-
 	tar --extract \
 		--file="${build_srcdir}.tar.gz" \
 		--strip-components=1 \

--- a/variants/posh.sh
+++ b/variants/posh.sh
@@ -44,8 +44,6 @@ shvr_build_posh ()
 
 	mkdir -p "${build_srcdir}"
 
-	shvr_deps_posh "$1"
-
 	tar --extract \
 		--file="${build_srcdir}.tar.gz" \
 		--strip-components=1 \

--- a/variants/yash.sh
+++ b/variants/yash.sh
@@ -61,8 +61,6 @@ shvr_build_yash ()
 
 	mkdir -p "${build_srcdir}"
 
-	shvr_deps_yash "$1"
-
 	tar --extract \
 		--file="${build_srcdir}.tar.gz" \
 		--strip-components=1 \

--- a/variants/yashrs.sh
+++ b/variants/yashrs.sh
@@ -44,11 +44,11 @@ shvr_download_yashrs ()
 
 shvr_build_yashrs ()
 {
+	. "$HOME/.cargo/env"
+
 	shvr_versioninfo_yashrs "$1"
 
 	mkdir -p "${build_srcdir}"
-
-	shvr_deps_yashrs "$1"
 
 	tar --extract \
 		--file="${build_srcdir}.tar.gz" \
@@ -76,6 +76,4 @@ shvr_deps_yashrs ()
 		shvr_download_rustup
 		sh "${SHVR_DIR_SRC}/rustup-init-1.28.2.sh" -y
 	fi
-
-	. "$HOME/.cargo/env"
 }

--- a/variants/zsh.sh
+++ b/variants/zsh.sh
@@ -76,7 +76,6 @@ shvr_build_zsh ()
 
 	mkdir -p "${build_srcdir}"
 
-	shvr_deps_zsh "$1"
 	if
 		{ test "$version_major" -gt 4 && test "${version_minor}" -gt 0; } ||
 		test "$version_major" -gt 5


### PR DESCRIPTION
This is a preparation intermediate step towards making the builds more modular. For now, we're just decoupling installing deps from the build step.