### PR TITLE
Add build checksums (not reproducible yet)

### DIFF
--- a/.github/actions/generate-build-checksums/action.yml
+++ b/.github/actions/generate-build-checksums/action.yml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+# SPDX-License-Identifier: ISC
+
+name: Generate and upload build checksums
+description: Extracts /opt from the built image, generates build checksums into checksums/build/, ensures correct ownership and uploads the artifact
+runs:
+  using: composite
+  steps:
+    - name: Extract image /opt
+      shell: bash
+      run: |
+        set -ex
+        container=$(docker create "${{ inputs.image }}")
+        docker cp $container:/opt ./image_out
+        docker rm $container
+
+    - name: Generate build checksums
+      shell: bash
+      env:
+        SHVR_DIR_OUT: ${{ github.workspace }}/image_out
+        SHVR_CHECKSUMS_DIR: ${{ github.workspace }}/checksums
+      run: |
+        set -ex
+        sh shvr.sh generate_build_checksums
+
+    - name: Ensure ownership of checksums
+      shell: bash
+      run: |
+        set -ex
+        # Some runners may create files as root when using docker, ensure runner can upload
+        sudo chown -R $(id -u):$(id -g) checksums/build || true
+
+    - name: Upload build checksums
+      uses: actions/upload-artifact@v6
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: checksums/build
+
+inputs:
+  image:
+    description: Docker image tag to extract (required)
+    required: true
+  artifact_name:
+    description: Artifact name to upload
+    required: false
+    default: shvr-build-checksums

--- a/.github/workflows/docker-all.yml
+++ b/.github/workflows/docker-all.yml
@@ -44,6 +44,12 @@ jobs:
           build-args: |
             TARGETS=${{ matrix.targets }}
 
+      - name: Generate and upload build checksums
+        uses: ./.github/actions/generate-build-checksums
+        with:
+          image: ${{ matrix.tags }}
+          artifact_name: shvr-build-checksums
+
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -44,6 +44,12 @@ jobs:
           build-args: |
             TARGETS=${{ matrix.targets }}
 
+      - name: Generate and upload build checksums
+        uses: ./.github/actions/generate-build-checksums
+        with:
+          image: ${{ matrix.tags }}
+          artifact_name: shvr-build-checksums
+
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -44,6 +44,12 @@ jobs:
           build-args: |
             TARGETS=${{ matrix.targets }}
 
+      - name: Generate and upload build checksums
+        uses: ./.github/actions/generate-build-checksums
+        with:
+          image: ${{ matrix.tags }}
+          artifact_name: shvr-build-checksums
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This is an intermediate step towards reproducible static builds. It just sets up a workflow for generating build checksums.

Those WILL vary after each build, since our scripts are still not ready to produce builds that are reproducible.

This step is in a long walk towards better builds, more reproducible results and perhaps even releases outside of docker.