### PR TITLE
Pin Rust toolchain and apt to snapshot.debian.org for reproducibility

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -104,8 +104,8 @@ jobs:
           build-args: |
             TOOLCHAIN_BASE=${{ needs.mirror.outputs.toolchain_ref }}
             RUNTIME_BASE=${{ needs.mirror.outputs.runtime_ref }}
-          cache-to: type=gha,scope=toolchain,mode=max
-          cache-from: type=gha,scope=toolchain
+          cache-to: type=gha,scope=toolchain-v3,mode=max
+          cache-from: type=gha,scope=toolchain-v3
 
   build:
     needs: [download, toolchain, mirror]
@@ -150,7 +150,7 @@ jobs:
             TOOLCHAIN_BASE=${{ needs.mirror.outputs.toolchain_ref }}
             RUNTIME_BASE=${{ needs.mirror.outputs.runtime_ref }}
           cache-from: |
-            type=gha,scope=toolchain
+            type=gha,scope=toolchain-v3
             type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-${{ matrix.target }}
           cache-to: >-
             ${{ github.event_name == 'push'

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,24 @@ ARG RUNTIME_BASE=busybox:stable-musl@sha256:3c6ae8008e2c2eedd141725c30b20d9c36b0
 
 FROM ${TOOLCHAIN_BASE} AS toolchain
 
+    # Pin apt sources to a specific snapshot.debian.org timestamp so the
+    # host toolchain (gcc, binutils, etc.) is bit-identical across builds
+    # and hosts. Without this, apt-get pulls live indexes and Debian
+    # security updates make the resulting musl-cross-make and stock cc
+    # drift over time, which propagates into every built binary. The
+    # chosen date matches the snapshot reference that debian:trixie-slim
+    # already records as a comment in its own debian.sources file.
+    ARG DEBIAN_SNAPSHOT=20260421T000000Z
+    # http (not https) because debian:trixie-slim lacks ca-certificates,
+    # and apt-get install can't run before apt-get update succeeds.
+    # snapshot.debian.org signs the InRelease files so integrity is still
+    # verified via the digest-pinned base's keyrings.
+    RUN sed -i \
+            -e "s|http://deb.debian.org/debian-security|http://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}|" \
+            -e "s|http://deb.debian.org/debian|http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}|" \
+            /etc/apt/sources.list.d/debian.sources && \
+        echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
+
     # Update distro
     RUN apt-get -y update
 
@@ -29,10 +47,15 @@ FROM ${TOOLCHAIN_BASE} AS toolchain
     # Build musl cross-compiler once (shared by all static variants)
     RUN bash "/shvr/shvr.sh" musl-build
 
-    # Pre-install Rust toolchain (used by brush and yashrs)
+    # Pre-install Rust toolchain (used by brush and yashrs). The toolchain
+    # version is pinned so the resulting binaries are bit-identical across
+    # hosts and runs; otherwise rustup-init downloads "latest stable" at
+    # image-build time, which drifts and breaks cross-host reproducibility.
+    # Bump when refreshing the base and regenerate the affected checksums.
+    ARG RUST_TOOLCHAIN=1.95.0
     COPY "build/rustup-init-*" "/usr/src/shvr/"
     COPY "checksums/sources/rustup-init-*" "/shvr/checksums/sources/"
-    RUN sh "${SHVR_DIR_SRC}/rustup-init-1.28.2.sh" -y && \
+    RUN sh "${SHVR_DIR_SRC}/rustup-init-1.28.2.sh" -y --default-toolchain "${RUST_TOOLCHAIN}" && \
         . "$HOME/.cargo/env" && \
         rustup target add x86_64-unknown-linux-musl
 
@@ -47,6 +70,13 @@ FROM toolchain AS builder
     COPY "variants/" "/shvr/variants"
 
     ARG TARGETS
+
+    # Refresh apt index before variant deps. The toolchain layer is heavily
+    # cached, and its `apt-get update` can point at packages that Debian has
+    # since security-updated and removed from the mirror; without this, the
+    # next `apt-get install` (from a variant's shvr_deps_<shell>) fails with
+    # "404 Not Found" or "Version 'X' not found".
+    RUN apt-get -y update
 
     # Build
     RUN bash "/shvr/shvr.sh" deps $TARGETS


### PR DESCRIPTION
Three Dockerfile/workflow changes that together make builds bit-identical across hosts (CI, x86_64 Linux developers, and aarch64 Mac developers using `--platform linux/amd64` with Rosetta).

1. Pin Rust to 1.95.0 via `--default-toolchain` to rustup-init. Before this, rustup-init installed "latest stable" at image-build time, so the cargo-built binaries (brush, yashrs) drifted every time the toolchain layer was rebuilt and were never bit-identical across hosts.

2. Pin apt sources to snapshot.debian.org/archive/debian/20260421T000000Z (the snapshot ref the digest-pinned debian:trixie-slim already records in its own debian.sources). The previous deb.debian.org URLs served whatever packages were current at apt-get-update time, so different hosts running apt-get on different days got different gcc-14 patch versions, which propagated into the cross-toolchain.

   http (not https) because the slim image lacks ca-certificates, and apt-get install can't run before apt-get update succeeds. `Acquire::Check-Valid-Until "false"` is set because snapshot indexes carry old Valid-Until headers that fail apt's freshness check.

3. Run `apt-get -y update` once at the top of the builder stage. The toolchain layer is heavily cached and its own apt index may be days or weeks old; if Debian has since security-updated and removed a package the variant's shvr_deps_<shell> needs (meson, ninja-build, gcc-12, etc.), `apt-get install` 404s on the .deb URL. loksh and ksh_2020 hit this in CI. Refreshing the index before deps install fixes it.

The toolchain GHA cache scope bumps to `toolchain-v3` so CI's next run fully rebuilds the toolchain layer with the new pins (otherwise the previous scope's cached layer would still be a hit candidate).

Note: cargo-built binaries (brush, yashrs) additionally require the build host to be x86_64 — rustc/LLVM output is not bit-identical across host architectures. Mac users need to pass `--platform linux/amd64` (Rosetta) when building and running. gcc-only shells (mksh, oksh, yash, etc.) reproduce regardless of host architecture.