### PR TITLE
Wrap up data-driven version migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,15 @@ This is particularly useful if you want to test a version that we don't bundle
 by default, such as an old patch. Our scripts are able to build most
 intermediate versions without modifications, but we can't include them all in
 any of the default images.
+
+## Updating the Version Lists
+
+The supported versions live in `versions/<shell>.{all,current}` (plus an optional
+`versions/<shell>.excluded` denylist). To pull in new upstream releases, run
+`sh shvr.sh update [<shell>]` (with no argument it updates every shell), which
+refreshes `versions/<shell>.all` from each shell's upstream source. Probe any
+newly-discovered versions before shipping them; if one fails to build with the
+current toolchain, add it to `versions/<shell>.excluded` (with a comment recording
+the failure) and re-run the update to drop it. Finally, run
+`sh shvr.sh github_regen_all` to regenerate the `.github/` build matrix from the
+data files, and commit `versions/` and `.github/` together.

--- a/shvr.sh
+++ b/shvr.sh
@@ -85,7 +85,6 @@ shvr_update ()
 	while test $# -gt 0
 	do
 		interpreter="$1"
-		shvr_clear_versioninfo
 		. "${SHVR_DIR_SELF}/variants/${interpreter}.sh"
 		if command -v "shvr_update_${interpreter}" >/dev/null 2>&1
 		then "shvr_update_${interpreter}"


### PR DESCRIPTION
Now that every shell reads from versions/<shell>.{all,current} via shvr_update_<shell>, drop the now-dead shvr_clear_versioninfo call in shvr_update: the updaters discover versions fresh and never read the version_*/fork_*/build_srcdir globals. The function and its two github_regen_* call sites (which clear then consume build_srcdir) are unchanged.

Document the maintainer update workflow in README.md (sh shvr.sh update, probe new versions, versions/<shell>.excluded, github_regen_all, commit).