### PR TITLE
CI: cache the toolchain in the registry for reliable matrix-wide reuse

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -132,8 +132,18 @@ jobs:
           build-args: |
             TOOLCHAIN_BASE=${{ needs.mirror.outputs.toolchain_ref }}
             RUNTIME_BASE=${{ needs.mirror.outputs.runtime_ref }}
-          cache-to: type=gha,scope=toolchain-v3,mode=max
-          cache-from: type=gha,scope=toolchain-v3
+          # Publish the toolchain build cache to the registry as well as GHA. A
+          # registry cache is content-addressed and reliably shared across the
+          # whole build matrix; the GHA cache is not dependable for a multi-GB
+          # toolchain read concurrently by every build job. Without this, when the
+          # toolchain layer changes (e.g. a shvr.sh edit) the per-target
+          # buildcaches go stale and every build job recompiles musl-cross-make.
+          cache-to: |
+            type=gha,scope=toolchain-v3,mode=max
+            ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/{0}:cache-toolchain,mode=max', github.repository) || '' }}
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}:cache-toolchain
+            type=gha,scope=toolchain-v3
 
   # Decide which targets actually need building. Each pushed per-target image
   # carries an org.shvr.oid annotation (its content-addressed build identity);
@@ -240,6 +250,7 @@ jobs:
             TOOLCHAIN_BASE=${{ needs.mirror.outputs.toolchain_ref }}
             RUNTIME_BASE=${{ needs.mirror.outputs.runtime_ref }}
           cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}:cache-toolchain
             type=gha,scope=toolchain-v3
             type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-${{ matrix.target }}
           cache-to: >-


### PR DESCRIPTION
The toolchain (musl-cross-make) was cached only to the GitHub Actions cache. GHA cache is not dependable for a multi-GB layer read concurrently by the whole build matrix, and the per-target registry buildcaches only carry a valid toolchain while the toolchain layer is unchanged. When that layer changes — e.g. any shvr.sh edit, since the Dockerfile COPYs shvr.sh into the toolchain stage before `musl-build` — the per-target buildcaches go stale and every build job falls back to the freshly rebuilt GHA cache, which many miss, so each recompiles musl-cross-make from scratch (the ~9-minute per-job toolchain build observed on the OIDV=2 run).

Publish the toolchain build cache to ghcr.io/<repo>:cache-toolchain (push only) and have the toolchain and build jobs read it first. A registry cache is content-addressed and reliably shared across concurrent jobs, so the toolchain is built at most once per run and every build job restores it.