### PR TITLE
version_sources: unique temp dir per html_listing call

### DIFF
--- a/common/version_sources/html_listing.sh
+++ b/common/version_sources/html_listing.sh
@@ -26,11 +26,17 @@ shvr_versions_from_html_listing ()
 	url="$1"
 	regex="$2"
 
-	base="${TMPDIR:-/tmp}/shvr_html_listing.$$"
-	raw="${base}.raw"
-	err="${base}.err"
-	out="${base}.out"
-	trap 'rm -f "$raw" "$err" "$out"' EXIT INT TERM
+	# A unique temp dir per call: $$ is the (shared) main-shell PID even inside this
+	# subshell function, so the previous "$$"-based paths collided when one call
+	# nested inside another — e.g. shvr_update_bash streams the baseline listing
+	# while calling this helper again per baseline to scrape its -patches/ dir. The
+	# inner call clobbered the outer's temp files, so patch discovery returned empty
+	# and every bash baseline composed to "<baseline>.0", freezing updates.
+	base="$(mktemp -d "${TMPDIR:-/tmp}/shvr_html_listing.XXXXXX")"
+	raw="${base}/raw"
+	err="${base}/err"
+	out="${base}/out"
+	trap 'rm -rf "$base"' EXIT INT TERM
 
 	if ! curl -fsSL "$url" > "$raw" 2> "$err"
 	then


### PR DESCRIPTION
shvr_versions_from_html_listing wrote its temp files to ${TMPDIR}/shvr_html_listing.$$, but $$ is the main shell's PID — identical in every nested subshell call. shvr_update_bash is the only updater that nests the helper (it streams the baseline listing while calling the helper again per baseline to scrape that baseline's -patches/ dir). The inner call clobbered the outer's temp files, so patch discovery returned empty and every bash baseline composed to "<baseline>.0". Since that is below the committed patch level, the series-filter merge kept the old version — `update` reported "no changes" and bash was frozen (stuck at 5.3.9 with 5.3.15 available).

Give each call its own `mktemp -d` directory so nested calls can't collide.