### PR TITLE
ci: publish the toolchain as an image instead of re-deriving it

### DIFF
--- a/.github/actions/build-push-retry/action.yml
+++ b/.github/actions/build-push-retry/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: 'Build args'
     required: false
     default: ''
+  build-contexts:
+    description: 'Named build contexts, e.g. toolchain=docker-image://ghcr.io/...; overrides the same-named Dockerfile stage'
+    required: false
+    default: ''
   cache-from:
     description: 'Cache sources'
     required: false
@@ -66,6 +70,7 @@ runs:
         push: ${{ inputs.push }}
         tags: ${{ inputs.tags }}
         build-args: ${{ inputs.build-args }}
+        build-contexts: ${{ inputs.build-contexts }}
         cache-from: ${{ inputs.cache-from }}
         cache-to: ${{ inputs.cache-to }}
         labels: ${{ inputs.labels }}
@@ -82,6 +87,7 @@ runs:
         push: ${{ inputs.push }}
         tags: ${{ inputs.tags }}
         build-args: ${{ inputs.build-args }}
+        build-contexts: ${{ inputs.build-contexts }}
         cache-from: ${{ inputs.cache-from }}
         cache-to: ${{ inputs.cache-to }}
         labels: ${{ inputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -105,15 +105,31 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   toolchain:
-    needs: [mirror]
+    needs: [mirror, plan]
+    # Nothing to build a toolchain for when the plan is empty, and the image is
+    # multi-GB to push. The build jobs gate on the same counts, and a job whose
+    # `needs` was skipped is skipped too, so this cannot leave a build job without
+    # its toolchain: if either arch has work, both toolchains are published.
+    if: needs.plan.outputs.count_amd64 != '0' || needs.plan.outputs.count_arm64 != '0'
     # One toolchain per arch, each on a native runner so its musl-cross-make and
     # Rust target build natively. Cache refs/scopes are arch-suffixed so the two
     # arches never cross-pollute each other's layers.
+    #
+    # This job PUBLISHES the toolchain as an image, and the build jobs consume it
+    # by name (see the build-contexts note there). It is not merely a cache warmer:
+    # a build job must never be able to re-derive the toolchain itself, because
+    # "re-derive" means compiling musl-cross-make in every one of ~250 jobs.
     strategy:
       fail-fast: false
       matrix:
         arch: [amd64, arm64]
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    env:
+      # Run-scoped, like the mirror job's tags: written by exactly one job in this
+      # run, read by that run's build jobs, and reaped by ghcr-cleanup.yml's
+      # `run-` filter. PR and push runs can never overwrite each other, and no
+      # long-lived shared tag is involved, so there is no cross-run race.
+      TOOLCHAIN_IMAGE: ghcr.io/${{ github.repository }}:run-${{ github.run_id }}-toolchain-${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/toolchain-downloads
@@ -130,22 +146,24 @@ jobs:
         with:
           driver-opts: image=${{ needs.mirror.outputs.buildkit_ref }}
 
-      - name: Build toolchain image
-        uses: docker/build-push-action@v7
+      - name: Build and push toolchain image
+        uses: ./.github/actions/build-push-retry
         with:
           context: .
           target: toolchain
-          push: false
+          push: "true"
+          tags: ${{ env.TOOLCHAIN_IMAGE }}
           platforms: linux/${{ matrix.arch }}
+          # Single-arch image, and nothing consumes an attestation manifest here;
+          # provenance would only add a manifest list the build jobs must resolve.
+          provenance: false
           build-args: |
             TOOLCHAIN_BASE=${{ needs.mirror.outputs.toolchain_ref }}
             RUNTIME_BASE=${{ needs.mirror.outputs.runtime_ref }}
-          # Publish the toolchain build cache to the registry as well as GHA. A
-          # registry cache is content-addressed and reliably shared across the
-          # whole build matrix; the GHA cache is not dependable for a multi-GB
-          # toolchain read concurrently by every build job. Without this, when the
-          # toolchain layer changes (e.g. a shvr.sh edit) the per-target
-          # buildcaches go stale and every build job recompiles musl-cross-make.
+          # Layer cache for THIS job only, so an unchanged toolchain is not
+          # recompiled every run. It is no longer load-bearing for the build jobs:
+          # they consume the image above, so a cache miss here costs one job per
+          # arch rather than a musl-cross-make compile in all ~250 of them.
           cache-to: |
             type=gha,scope=toolchain-${{ matrix.arch }}-v3,mode=max
             ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/{0}:cache-toolchain-{1},mode=max', github.repository, matrix.arch) || '' }}
@@ -273,9 +291,28 @@ jobs:
             TARGETS=${{ matrix.target }}
             TOOLCHAIN_BASE=${{ needs.mirror.outputs.toolchain_ref }}
             RUNTIME_BASE=${{ needs.mirror.outputs.runtime_ref }}
+          # THE toolchain contract. `toolchain` names a stage in the Dockerfile
+          # (FROM ${TOOLCHAIN_BASE} AS toolchain), and a named build context of the
+          # same name REPLACES that stage with this image -- so the stage is never
+          # executed here and musl-cross-make is never compiled in a build job.
+          #
+          # This is what makes toolchain reuse a fact rather than a cache-hit
+          # lottery. Previously the stage was local and reuse depended entirely on
+          # a layer-cache hit; a stale or evicted cache silently recompiled the
+          # toolchain in EVERY one of the ~250 build jobs. Silently, because a
+          # cache miss is not an error in BuildKit -- it just does the work again.
+          # Now a missing toolchain image is a hard pull failure instead.
+          #
+          # Do not delete this and do not "simplify" it back into cache-from.
+          # workflow-verification.yml fails the build if an `artifacts` build has
+          # no toolchain build context.
+          build-contexts: |
+            toolchain=docker-image://ghcr.io/${{ github.repository }}:run-${{ github.run_id }}-toolchain-${{ matrix.arch }}
+          # Only the builder-stage layers are cached per target now. The toolchain
+          # cache refs are deliberately absent: the stage above is not built here,
+          # so listing them would just make every job pull multi-GB of cache
+          # metadata it cannot use.
           cache-from: |
-            type=registry,ref=ghcr.io/${{ github.repository }}:cache-toolchain-${{ matrix.arch }}
-            type=gha,scope=toolchain-${{ matrix.arch }}-v3
             type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-${{ matrix.target }}-${{ matrix.arch }}
           cache-to: >-
             ${{ github.event_name == 'push'
@@ -347,9 +384,28 @@ jobs:
             TARGETS=${{ matrix.target }}
             TOOLCHAIN_BASE=${{ needs.mirror.outputs.toolchain_ref }}
             RUNTIME_BASE=${{ needs.mirror.outputs.runtime_ref }}
+          # THE toolchain contract. `toolchain` names a stage in the Dockerfile
+          # (FROM ${TOOLCHAIN_BASE} AS toolchain), and a named build context of the
+          # same name REPLACES that stage with this image -- so the stage is never
+          # executed here and musl-cross-make is never compiled in a build job.
+          #
+          # This is what makes toolchain reuse a fact rather than a cache-hit
+          # lottery. Previously the stage was local and reuse depended entirely on
+          # a layer-cache hit; a stale or evicted cache silently recompiled the
+          # toolchain in EVERY one of the ~250 build jobs. Silently, because a
+          # cache miss is not an error in BuildKit -- it just does the work again.
+          # Now a missing toolchain image is a hard pull failure instead.
+          #
+          # Do not delete this and do not "simplify" it back into cache-from.
+          # workflow-verification.yml fails the build if an `artifacts` build has
+          # no toolchain build context.
+          build-contexts: |
+            toolchain=docker-image://ghcr.io/${{ github.repository }}:run-${{ github.run_id }}-toolchain-${{ matrix.arch }}
+          # Only the builder-stage layers are cached per target now. The toolchain
+          # cache refs are deliberately absent: the stage above is not built here,
+          # so listing them would just make every job pull multi-GB of cache
+          # metadata it cannot use.
           cache-from: |
-            type=registry,ref=ghcr.io/${{ github.repository }}:cache-toolchain-${{ matrix.arch }}
-            type=gha,scope=toolchain-${{ matrix.arch }}-v3
             type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-${{ matrix.target }}-${{ matrix.arch }}
           cache-to: >-
             ${{ github.event_name == 'push'

--- a/.github/workflows/workflow-verification.yml
+++ b/.github/workflows/workflow-verification.yml
@@ -34,6 +34,53 @@ jobs:
             exit 1
           fi
 
+      # The toolchain contract, enforced.
+      #
+      # `FROM toolchain AS builder` names a stage that lives in the Dockerfile, so
+      # any build of a stage below it can re-derive the toolchain -- which means
+      # compiling musl-cross-make. BuildKit does that SILENTLY on a cache miss: it
+      # is not an error, just half an hour of work, once per build job, across
+      # ~250 jobs. That is the bug this check exists to prevent from returning.
+      #
+      # The build jobs must therefore pass a `toolchain` named build context
+      # pointing at the image the toolchain job published, which replaces the
+      # stage outright. Then reuse is a fact, and a missing toolchain image is a
+      # loud pull failure rather than a quiet recompile.
+      #
+      # So: every step that builds the `artifacts` target must carry a
+      # `toolchain=docker-image://` build context. If you are here because this
+      # check failed, do not delete the check.
+      - name: Check the toolchain is consumed as an image, not rebuilt
+        run: |
+          awk '
+            function flush() {
+              if (artifacts && !context) {
+                printf "%s:%d: builds target `artifacts` with no toolchain build context\n", FILENAME, start
+                bad = 1
+              }
+              artifacts = 0; context = 0
+            }
+            /^[[:space:]]*-[[:space:]]+(name|uses):/ { flush(); start = NR }
+            /^[[:space:]]*target:[[:space:]]*artifacts[[:space:]]*$/ { artifacts = 1 }
+            /toolchain=docker-image:\/\// { context = 1 }
+            END {
+              flush()
+              if (bad) {
+                print ""
+                print "Every `artifacts` build must consume the toolchain image published by"
+                print "the toolchain job, via:"
+                print ""
+                print "    build-contexts: |"
+                print "      toolchain=docker-image://ghcr.io/<repo>:run-<run_id>-toolchain-<arch>"
+                print ""
+                print "Without it the build re-derives the toolchain stage from source, and"
+                print "BuildKit does so silently -- every build job recompiles musl-cross-make."
+                exit 1
+              }
+            }
+          ' .github/workflows/docker.yml
+          echo "toolchain contract: ok"
+
   verify-checksums:
     runs-on: ubuntu-24.04
     timeout-minutes: 15

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,14 @@ FROM ${TOOLCHAIN_BASE} AS toolchain
         rustup target add "$(shvr_rust_target)"
 
 
+# In CI this `toolchain` is NOT this file's toolchain stage. The build jobs pass
+# a named build context (`--build-context toolchain=docker-image://...`) pointing
+# at the image the toolchain job published, which replaces the stage wholesale, so
+# musl-cross-make is compiled once per arch per run instead of once per build job.
+# See the build-contexts note in .github/workflows/docker.yml.
+#
+# A plain `docker build` passes no such context, so the stage above is used and a
+# local build still works end to end -- just slowly, the first time.
 FROM toolchain AS builder
 
     # Copy contents


### PR DESCRIPTION
The toolchain job built `target: toolchain` with `push: false`. It produced no artifact at all -- only a layer cache. Meanwhile `FROM toolchain AS builder` is a stage in the same Dockerfile, and the ~250 per-target build jobs each ran that same Dockerfile on a fresh runner with a cold local BuildKit. So every build job *re-derived* the toolchain, and the only thing standing between it and a full musl-cross-make compile was a remote cache hit.

That is the bug. A cache miss is not an error in BuildKit -- it just silently does the work again. Stale or evicted cache therefore does not fail; it quietly recompiles the toolchain 250 times.

Cache tuning cannot fix this, and the comment that used to sit on the toolchain job is the evidence: a registry cache-to was added precisely because "the GHA cache is not dependable for a multi-GB toolchain read concurrently by every build job". That treats the symptom. The disease is that reuse was a cache-hit lottery rather than a fact.

So publish the toolchain. The toolchain job now pushes a real per-arch image to a run-scoped GHCR tag, exactly as the mirror job already does for the base images (and ghcr-cleanup.yml's `run-` filter already reaps it). The build jobs consume it with a named build context:

    build-contexts: |
      toolchain=docker-image://ghcr.io/<repo>:run-<run_id>-toolchain-<arch>

A named context replaces the same-named Dockerfile stage outright, so the stage is never executed in a build job and musl-cross-make is compiled once per arch per run. A missing toolchain image is now a hard pull failure instead of a quiet half-hour recompile -- the failure mode is loud, which is the point.

Two consequences worth naming:

  - The build jobs no longer list the toolchain cache refs. They were not merely useless once the stage stopped being built, they were expensive: every job was pulling multi-GB of cache metadata it could not use.
  - The toolchain job keeps its own cache, but it is no longer load-bearing. A miss there now costs one job per arch, not a compile in all of them.

To stop this from coming back, workflow-verification.yml fails if any step that builds the `artifacts` target lacks a toolchain build context -- the exact edit that would silently restore the old behaviour. The check was tested by removing the context and confirming it fails, with line numbers.

The toolchain job also gates on the plan being non-empty, so a no-op run does not push a multi-GB image for nothing. A plain `docker build` passes no named context, so the local stage is still used and building the Dockerfile by hand still works.