### PR TITLE
ci: let a PR's build cache survive into the merge

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -105,12 +105,28 @@ jobs:
           # cache refs are deliberately absent: the stage above is not built here,
           # so listing them would just make every job pull multi-GB of cache
           # metadata it cannot use.
+          #
+          # Two refs, one per event, and main reads both. A PR used to export
+          # NOWHERE (cache-to rendered to the empty string), so the merge that
+          # followed compiled from scratch against a buildcache still holding
+          # pre-PR layers -- the PR's work was thrown away every time. A PR now
+          # exports to its own `-pr` ref, which the push build also reads, so the
+          # merge replays those layers instead of recompiling them.
+          #
+          # The `-pr` ref is separate on purpose: PRs must never displace the
+          # authoritative cache. Last-writer-wins on a shared ref would let an
+          # experimental or abandoned PR evict main's layers, costing later runs a
+          # miss for no reason. Only a push writes the authoritative ref.
+          #
+          # ignore-error keeps a cache export from failing an otherwise-good
+          # build (a fork PR gets no packages:write and cannot export at all).
           cache-from: |
             type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-${{ matrix.target }}-${{ matrix.arch }}
+            type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-pr-${{ matrix.target }}-${{ matrix.arch }}
           cache-to: >-
             ${{ github.event_name == 'push'
-              && format('type=registry,ref=ghcr.io/{0}:buildcache-{1}-{2},mode=max', github.repository, matrix.target, matrix.arch)
-              || '' }}
+              && format('type=registry,ref=ghcr.io/{0}:buildcache-{1}-{2},mode=max,ignore-error=true', github.repository, matrix.target, matrix.arch)
+              || format('type=registry,ref=ghcr.io/{0}:buildcache-pr-{1}-{2},mode=max,ignore-error=true', github.repository, matrix.target, matrix.arch) }}
           # Single-manifest image so the OID annotation sits at the manifest top
           # level, readable via `imagetools inspect --raw` without pulling layers.
           # The OID comes from the plan matrix entry (shvr_plan_matrix) and is

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -164,11 +164,21 @@ jobs:
           # recompiled every run. It is no longer load-bearing for the build jobs:
           # they consume the image above, so a cache miss here costs one job per
           # arch rather than a musl-cross-make compile in all ~250 of them.
+          #
+          # The registry export used to be push-only, which left a PR that moved
+          # the toolchain fingerprint with nothing main could reuse: the type=gha
+          # entry below does not cross the PR->main boundary, because GitHub scopes
+          # a feature branch's cache away from the default branch (main can never
+          # read a PR branch's entries). So main recompiled musl-cross-make even
+          # though the PR had just done it. A PR now exports to its own `-pr` ref,
+          # which the push build reads too. Separate ref for the same reason as the
+          # per-target buildcache: a PR must not displace the authoritative one.
           cache-to: |
             type=gha,scope=toolchain-${{ matrix.arch }}-v3,mode=max
-            ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/{0}:cache-toolchain-{1},mode=max', github.repository, matrix.arch) || '' }}
+            ${{ github.event_name == 'push' && format('type=registry,ref=ghcr.io/{0}:cache-toolchain-{1},mode=max,ignore-error=true', github.repository, matrix.arch) || format('type=registry,ref=ghcr.io/{0}:cache-toolchain-pr-{1},mode=max,ignore-error=true', github.repository, matrix.arch) }}
           cache-from: |
             type=registry,ref=ghcr.io/${{ github.repository }}:cache-toolchain-${{ matrix.arch }}
+            type=registry,ref=ghcr.io/${{ github.repository }}:cache-toolchain-pr-${{ matrix.arch }}
             type=gha,scope=toolchain-${{ matrix.arch }}-v3
 
   # Decide which targets actually need building. Each pushed per-target image


### PR DESCRIPTION
A merge to main recompiled shells that the PR had just built. Not because the cache was stale -- because there was no cache. cache-to on the per-target build was gated on `github.event_name == 'push'`, and the `|| ''` fallback meant a pull_request exported its layers NOWHERE. The merge then read a buildcache-<target>-<arch> ref still holding pre-PR layers, missed, and did the whole compile again. The toolchain job had the same gate, and its ungated type=gha entry is no help: GitHub scopes a feature branch's cache away from the default branch, so main can never read what a PR branch wrote.

A PR now exports to its own ref -- buildcache-pr-<target>-<arch> and cache-toolchain-pr-<arch> -- and the push build lists both refs in cache-from, so the merge replays those layers instead of recompiling them.

The `-pr` ref is separate rather than shared. Registry cache is last-writer-wins, so letting PRs write the authoritative ref would let an experimental or abandoned branch evict main's layers and cost later runs a miss for no reason. Only a push writes the authoritative ref; nothing a PR does can degrade it.

Both exports carry ignore-error so a cache export cannot fail an otherwise-good build -- a fork PR gets no packages:write and cannot export at all. A missing cache ref is a warning in BuildKit, not an error, so the first run after this lands simply misses.

This does not stop the merge from scheduling the work; it stops the work from being redone. Skipping it outright needs the plan job to find what the PR already published, which is a separate change.