### PR TITLE
ci: open per-shell update PRs, and stop build_updated from rebuilding…

### DIFF
--- a/.github/workflows/update-group.yml
+++ b/.github/workflows/update-group.yml
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+# SPDX-License-Identifier: ISC
+
+# Reusable: build one SOURCE-GROUP's new versions for both arches and open/update
+# a single PR for it. Called once per changed group by update-prs.yml. A group is
+# a source (shvr_group_of): busybox = ash+hush share one tree and one PR; every
+# other shell is its own group. One call -> one durable PR on branch update/<group>.
+name: Update a source-group
+
+on:
+  workflow_call:
+    inputs:
+      group:
+        description: "Source-group key (e.g. busybox, dash) — names the branch update/<group>"
+        required: true
+        type: string
+      shells:
+        description: "Space-separated shells in this group to build (e.g. \"ash hush\")"
+        required: true
+        type: string
+      versions_artifact:
+        description: "Artifact holding the planned versions/ tree (uploaded by the plan job)"
+        required: true
+        type: string
+      dry_run:
+        description: "Build and diff, but do not push a branch or open a PR"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  packages: read
+  pull-requests: write
+
+# One in-flight run per group: two overlapping runs would race the shared
+# update/<group> branch. Newer wins; the older is cancelled before it pushes.
+concurrency:
+  group: update-group-${{ inputs.group }}
+  cancel-in-progress: true
+
+jobs:
+  # Build the group's new versions natively per arch and hand its regenerated
+  # checksums (+ the group's versions files) up as an artifact. Native runners so
+  # arm64 is not emulated, matching docker.yml.
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      # Overlay ONLY this group's version files. They are named by source
+      # (versions/<group>.*; ash/hush carry none of their own — they read
+      # busybox's), so restoring just these means build_updated's global prune
+      # drops only THIS group's removed versions and never another group's,
+      # keeping the PR scoped. The rest of versions/ stays at main's state.
+      - name: Restore this group's planned versions
+        uses: actions/download-artifact@v6
+        with:
+          name: ${{ inputs.versions_artifact }}
+          path: planned-versions
+      - name: Overlay versions/${{ inputs.group }}.*
+        run: |
+          set -eu
+          cp -a "planned-versions/${{ inputs.group }}".* versions/
+          rm -rf planned-versions
+          echo "versions/${{ inputs.group }}.* after overlay:" >&2
+          ls -1 "versions/${{ inputs.group }}".* >&2
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v4
+
+      # build_updated fetches this group's new sources (skip-verify) + mints their
+      # SOURCE checksums, then builds the arch's missing targets and writes its
+      # BUILD checksums, then prunes the group's dropped versions. SHVR_BUILD_ARCHES
+      # pins it to this runner's arch; SHVR_BUILD_CACHE_FROM warms the toolchain
+      # from the committed registry cache so musl-cross-make is a cache hit, not a
+      # ~30-min recompile per job.
+      - name: Build updated versions and regenerate checksums (${{ matrix.arch }})
+        env:
+          SHVR_BUILD_ARCHES: ${{ matrix.arch }}
+          SHVR_BUILD_CACHE_FROM: ghcr.io/${{ github.repository }}:cache-toolchain-${{ matrix.arch }}
+          # Via env, never interpolated into the command text: build_updated takes
+          # a word-split shell list, so SHELLS is expanded unquoted (SC2086), but
+          # a ${{ }} splice into `run:` would be a script-injection surface. Same
+          # safe pattern the plan job uses (update-prs.yml).
+          SHELLS: ${{ inputs.shells }}
+        # shellcheck disable=SC2086
+        run: sh shvr.sh build_updated $SHELLS
+
+      # Hand up exactly what this group changed: its versions files, its source
+      # checksums, and this arch's build checksums. The collate job fuses the two
+      # arches. A build that produced nothing is caught by the build step's
+      # non-zero exit above, not here: versions/ and checksums/sources always
+      # exist, so if-no-files-found stays a cheap backstop for a mis-typed path,
+      # not a build-empty detector.
+      - name: Upload this group's changes (${{ matrix.arch }})
+        uses: actions/upload-artifact@v6
+        with:
+          name: update-${{ inputs.group }}-${{ matrix.arch }}
+          if-no-files-found: error
+          path: |
+            versions/${{ inputs.group }}.*
+            checksums/sources
+            checksums/build/${{ matrix.arch }}
+
+  # Fuse both arches' checksums, commit, and open/refresh one PR for the group.
+  collate-and-pr:
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      # Both arch artifacts unpack onto the clean checkout. versions/ and
+      # checksums/sources are identical across arches (arch-neutral); each arch
+      # contributes its own checksums/build/<arch>. Later extraction wins on the
+      # shared paths, which is a no-op since they match.
+      - uses: actions/download-artifact@v6
+        with:
+          name: update-${{ inputs.group }}-amd64
+          path: .
+      - uses: actions/download-artifact@v6
+        with:
+          name: update-${{ inputs.group }}-arm64
+          path: .
+
+      # Artifacts overlay ADDITIVELY — they add the new version's files but cannot
+      # express a deletion. A version this bump DROPS (e.g. dash 0.5.13.4 -> .5)
+      # still has its build-checksum dirs in the checked-out main tree. prune
+      # removes exactly those: it keeps the buildset, and only this group's
+      # versions are overlaid, so only this group's dropped versions are reaped —
+      # other groups stay at main's state and are untouched. (Source checksums are
+      # not pruned by design, matching the rest of the repo.)
+      - name: Prune dropped versions' build checksums
+        run: sh shvr.sh prune_build_checksums
+
+      - name: Show the group's diff
+        run: |
+          set -eu
+          git add -A versions checksums
+          git --no-pager diff --cached --stat
+          if git diff --cached --quiet; then
+            echo "No changes for group ${{ inputs.group }} — nothing to PR." >&2
+            echo "changed=no" >> "$GITHUB_ENV"
+          else
+            echo "changed=yes" >> "$GITHUB_ENV"
+          fi
+
+      # dry-run stops here: the staged diff above is the artifact to inspect, and
+      # the tree is uploaded so a reviewer can see exactly what a real run would
+      # commit — without a branch or PR existing.
+      - name: Upload proposed changes (dry-run)
+        if: ${{ inputs.dry_run && env.changed == 'yes' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: proposed-${{ inputs.group }}
+          path: |
+            versions/${{ inputs.group }}.*
+            checksums
+
+      # Real run: one durable PR per group. Stable branch update/<group> means a
+      # re-run refreshes the same PR instead of opening a new one (no spam).
+      # NOTE: a PR opened with the default GITHUB_TOKEN does NOT trigger the
+      # pull_request build (docker.yml) — GitHub blocks token-created events from
+      # cascading. Set repo secret UPDATE_PR_TOKEN to a PAT to have the update PR
+      # run CI automatically; otherwise re-run CI once by hand (e.g. close/reopen).
+      - name: Create or update the group PR
+        if: ${{ !inputs.dry_run && env.changed == 'yes' }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.UPDATE_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          branch: update/${{ inputs.group }}
+          base: main
+          add-paths: |
+            versions
+            checksums
+          commit-message: "update: ${{ inputs.group }} new version(s)"
+          title: "update: ${{ inputs.group }} new version(s)"
+          body: |
+            Automated version bump for the **${{ inputs.group }}** source-group
+            (shells: `${{ inputs.shells }}`), opened by the `update-prs` workflow.
+
+            Contains the group's `versions/` bump plus regenerated source and
+            per-arch build checksums (amd64 + arm64). If CI did not start
+            automatically, this PR was created with the default token; re-run it
+            by hand or configure `UPDATE_PR_TOKEN`.
+          delete-branch: false

--- a/.github/workflows/update-prs.yml
+++ b/.github/workflows/update-prs.yml
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+# SPDX-License-Identifier: ISC
+
+# Discover upstream version bumps and open ONE pull request per source-group,
+# each carrying that group's versions/ bump plus regenerated source and both-arch
+# build checksums (so its CI goes green — new versions have no committed build
+# checksums, and the assemble job fails closed on that).
+#
+# Dispatch-only for now. Run it by hand (dry_run first) until it is trusted, THEN
+# add a `schedule:` trigger. The design already tolerates cron: on a scheduled run
+# workflow_dispatch inputs do not exist, so `inputs.shells` is empty (= every
+# changed group) and inputs.dry_run is false — exactly the "one PR per group"
+# behaviour, with no code path that depends on the inputs being present.
+name: Open per-group update PRs
+
+on:
+  workflow_dispatch:
+    inputs:
+      shells:
+        description: "Restrict to these shells (space-separated); empty = all changed groups"
+        required: false
+        default: ""
+        type: string
+      dry_run:
+        description: "Plan and build, but do not open PRs"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  packages: read
+  pull-requests: write
+
+# Serialize whole runs: the plan job mutates versions/ and each group races its
+# own branch. One run at a time keeps discovery and branch state coherent.
+concurrency:
+  group: update-prs
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    runs-on: ubuntu-24.04
+    outputs:
+      # matrix = {"include":[{"group":..,"shells":".."}]} over changed groups.
+      matrix: ${{ steps.plan.outputs.matrix }}
+      count: ${{ steps.plan.outputs.count }}
+    steps:
+      # Full history so shvr update's git-based snapshot discovery works.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # Bring versions/ up to date. This mutates the working tree only; nothing is
+      # committed here — the per-group jobs turn slices of it into PRs.
+      - name: Discover new versions
+        run: sh shvr.sh update
+
+      # Grouping is arch-neutral (a new version is missing on both arches, and
+      # .current/.snapshot are identical across them), so amd64 is representative.
+      # inputs.shells is empty on cron -> no filter -> every changed group.
+      - name: Plan changed groups
+        id: plan
+        env:
+          SHELLS: ${{ inputs.shells }}
+        run: |
+          set -eu
+          # shellcheck disable=SC2086
+          groups="$(SHVR_ARCH=amd64 sh shvr.sh updated_groups $SHELLS)"
+
+          # Fold "<group> <shell...>" lines into a GH matrix. jq -R/-s reads the
+          # whole text; each non-empty line becomes one include entry.
+          matrix="$(printf '%s\n' "$groups" \
+            | jq -R -s -c '
+                {include:
+                  [ split("\n")[]
+                    | select(length > 0)
+                    | (split(" ")) as $f
+                    | {group: $f[0], shells: ($f[1:] | join(" "))} ]}')"
+          count="$(printf '%s' "$matrix" | jq '.include | length')"
+
+          printf 'matrix=%s\n' "$matrix" >> "$GITHUB_OUTPUT"
+          printf 'count=%s\n'  "$count"  >> "$GITHUB_OUTPUT"
+          {
+            echo "### Update plan"
+            if [ "$count" = 0 ]; then echo "No new versions."; else
+              printf '%s\n' "$groups" | sed 's/^/- /'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # The exact versions/ this run discovered, so every group job slices from the
+      # same snapshot instead of re-running update and racing a newer upstream.
+      - name: Upload planned versions
+        if: steps.plan.outputs.count != '0'
+        uses: actions/upload-artifact@v6
+        with:
+          name: shvr-planned-versions
+          path: versions
+          include-hidden-files: false
+
+  # One reusable-workflow call per changed group. max-parallel is the queue: it
+  # bounds how many groups build/PR at once so a big update wave does not fire N
+  # full CI runs simultaneously. Durable per-group branches mean a throttled or
+  # re-run group refreshes its existing PR rather than spawning another.
+  group:
+    needs: plan
+    if: needs.plan.outputs.count != '0'
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    uses: ./.github/workflows/update-group.yml
+    with:
+      group: ${{ matrix.group }}
+      shells: ${{ matrix.shells }}
+      versions_artifact: shvr-planned-versions
+      # `|| false` so a scheduled run (where inputs.dry_run is null) passes a real
+      # boolean, not null, to the reusable workflow's typed input.
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit

--- a/.github/workflows/workflow-verification.yml
+++ b/.github/workflows/workflow-verification.yml
@@ -106,28 +106,42 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Resolve the dash target at runtime instead of hardcoding a version. The
+      # test needs a dash version that is committed (has a source checksum) and
+      # fetchable upstream; `current dash` is exactly that and it tracks version
+      # bumps, so an `update` that rotates dash (e.g. 0.5.13.4 -> 0.5.13.5) no
+      # longer strands this job on a version whose tarball has 404'd.
+      - name: 'Resolve a stable dash target'
+        run: |
+          set -eu
+          ver="$(sh shvr.sh current dash | head -n1)"   # e.g. dash_0.5.13.5
+          ver="${ver#dash_}"
+          test -n "$ver"
+          test -f "checksums/sources/dash/${ver}.tar.gz.sha256sums"
+          echo "DASH_VER=${ver}" >> "$GITHUB_ENV"
+
       - name: 'Download Verification'
         run: |
           set -ex
           # ensure clean state and perform an initial download (should succeed)
-          rm -f build/dash/0.5.13.4.tar.gz
-          sh shvr.sh download dash_0.5.13.4
+          rm -f "build/dash/${DASH_VER}.tar.gz"
+          sh shvr.sh download "dash_${DASH_VER}"
 
       - name: 'Corrupt checksum and assert download fails'
         run: |
           set -ex
           # backup checksum file
-          cp checksums/sources/dash/0.5.13.4.tar.gz.sha256sums checksums/sources/dash/0.5.13.4.tar.gz.sha256sums.bak
+          cp "checksums/sources/dash/${DASH_VER}.tar.gz.sha256sums" "checksums/sources/dash/${DASH_VER}.tar.gz.sha256sums.bak"
           # corrupt checksum: replace hash with ones; keep filename
-          printf '1111111111111111111111111111111111111111111111111111111111111111  %s\n' "0.5.13.4.tar.gz" > checksums/sources/dash/0.5.13.4.tar.gz.sha256sums
+          printf '1111111111111111111111111111111111111111111111111111111111111111  %s\n' "${DASH_VER}.tar.gz" > "checksums/sources/dash/${DASH_VER}.tar.gz.sha256sums"
           # remove any existing artifact to force re-download
-          rm -f build/dash/0.5.13.4.tar.gz
+          rm -f "build/dash/${DASH_VER}.tar.gz"
           set +e
           # attempt download once; if the worker network is flaky this may fail
           # for reasons other than checksum mismatch. Capture logs and RC so we
           # can differentiate mismatch from other failures.
           # run the download and capture the exit code; write logs to file
-          sh shvr.sh download dash_0.5.13.4 > download.log 2>&1
+          sh shvr.sh download "dash_${DASH_VER}" > download.log 2>&1
           rc=$?
           # show the log to the step output so it appears in CI
           cat download.log
@@ -147,6 +161,6 @@ jobs:
       - name: 'Restore checksum and verify success'
         run: |
           set -ex
-          mv checksums/sources/dash/0.5.13.4.tar.gz.sha256sums.bak checksums/sources/dash/0.5.13.4.tar.gz.sha256sums
-          rm -f build/dash/0.5.13.4.tar.gz
-          sh shvr.sh download dash_0.5.13.4
+          mv "checksums/sources/dash/${DASH_VER}.tar.gz.sha256sums.bak" "checksums/sources/dash/${DASH_VER}.tar.gz.sha256sums"
+          rm -f "build/dash/${DASH_VER}.tar.gz"
+          sh shvr.sh download "dash_${DASH_VER}"

--- a/shvr.sh
+++ b/shvr.sh
@@ -59,6 +59,60 @@ shvr_updated_targets ()
 	done
 }
 
+# The update-PR unit for a shell: its SOURCE, so shells built from one tree share
+# one PR (and one build). ash and hush both declare busybox via
+# shvr_versionsource_<shell> (see variants/ash.sh), so both map to "busybox";
+# every other shell owns its source and maps to itself. This is the same hook the
+# version machinery already keys off, so groups never drift from how trees build.
+# Subshell: the variant is sourced on demand (like every other generic command
+# here) so the hook is visible, without leaking its definitions to the caller.
+shvr_group_of ()
+(
+	if test -f "${SHVR_DIR_SELF}/variants/$1.sh"
+	then . "${SHVR_DIR_SELF}/variants/$1.sh"
+	fi
+	if command -v "shvr_versionsource_$1" >/dev/null 2>&1
+	then "shvr_versionsource_$1"
+	else echo "$1"
+	fi
+)
+
+# One line per source-group that has a new version for the current SHVR_ARCH:
+#   <group> <shell> [<shell>...]
+# The shells are those in the group with at least one updated target; the group
+# key is shvr_group_of. Drives the per-group matrix of the update-PR workflow:
+# one line -> one PR. A shell's released bump and its snapshot bump are both
+# <shell> targets, so they collapse into the same group (one PR carries both).
+# Optional <shell> args narrow the scan (a manual, single-group run); no args =
+# every changed group (the cron default). Groups and their shells come out in
+# first-seen order, so the output is stable for a given updated-target set.
+shvr_updated_groups ()
+{
+	# Reduce the updated targets to their DISTINCT shells first (a shell with
+	# both a release and a snapshot bump appears twice), so shvr_group_of -- which
+	# sources the shell's variant and its common/*.sh -- runs once per shell, not
+	# once per target. Then emit "<group> <shell>" and let awk fold shells into
+	# their group in first-seen order.
+	shells_seen=" "
+	for t in $(shvr_updated_targets "$@")
+	do
+		sh_name="${t%%_*}"
+		case "$shells_seen" in *" $sh_name "*) continue ;; esac
+		shells_seen="${shells_seen}${sh_name} "
+		printf '%s %s\n' "$(shvr_group_of "$sh_name")" "$sh_name"
+	done | awk '
+		{
+			# Shells are already distinct, so each group accumulates its members
+			# in first-seen order. Test membership BEFORE assigning shells[$1]:
+			# referencing it on a statement LHS vivifies it, so a same-statement
+			# (in) test would always be true and prepend a stray leading space.
+			if ($1 in shells) { shells[$1] = shells[$1] " " $2 }
+			else { order[++n] = $1; shells[$1] = $2 }
+		}
+		END { for (i = 1; i <= n; i++) print order[i] " " shells[order[i]] }
+	'
+}
+
 # Remove committed build-checksum dirs for targets no longer supported. The keep set is
 # always the full current build set — shvr_buildset (released + pre-release), plus
 # shvr_testing when that command exists. Keying off shvr_buildset rather than
@@ -118,6 +172,21 @@ shvr_build_updated_arch ()
 (
 	arch="$1"
 	shift
+
+	# Require explicit targets. Without this guard an empty list flows into
+	# `docker build --build-arg TARGETS=""`, and inside the container
+	# `shvr.sh build` with no args falls back to the WHOLE buildset (~300
+	# targets, toolchain included) -- a full from-scratch rebuild masquerading
+	# as "build the new versions". The intended entry point is shvr_build_updated
+	# (no arch), which computes the targets; this helper is only ever called with
+	# them. Fail loudly rather than silently rebuild everything.
+	if test -z "$*"
+	then
+		echo "shvr_build_updated_arch: no targets given (usage: build_updated_arch <arch> <target>...)." >&2
+		echo "  To build every new version, use: shvr.sh build_updated" >&2
+		return 2
+	fi
+
 	tag="shvr-build-updated-${arch}"
 	# Scratch dir for the extracted /opt, outside the repo so nothing is polluted.
 	# Subshell function (parens) so this EXIT trap is scoped to the call.
@@ -127,9 +196,21 @@ shvr_build_updated_arch ()
 	echo "build_updated[${arch}]: docker build (linux/${arch}) for: $*" >&2
 
 	# Single-platform build loaded into the local engine so we can extract from it.
+	# Optional layer-cache sources, one registry ref per line/word in
+	# SHVR_BUILD_CACHE_FROM. Unset locally (podman/buildah ignores registry cache
+	# anyway), so the local build is unchanged. CI sets it to the committed
+	# toolchain cache ref (ghcr.io/<repo>:cache-toolchain-<arch>) so the ~30-min
+	# musl-cross-make compile is a cache hit instead of running in every job.
+	cache_from_args=""
+	for _ref in ${SHVR_BUILD_CACHE_FROM:-}
+	do cache_from_args="${cache_from_args} --cache-from=${_ref}"
+	done
+
+	# shellcheck disable=SC2086
 	docker buildx build \
 		--platform "linux/${arch}" \
 		--build-arg TARGETS="$*" \
+		$cache_from_args \
 		--load \
 		-t "$tag" \
 		"${SHVR_DIR_SELF}"


### PR DESCRIPTION
… everything

`shvr.sh update` then `build_updated_arch amd64` (no targets) kicked off a full ~300-target rebuild instead of the new versions: an empty target list flows into `docker build --build-arg TARGETS=""`, and inside the container `shvr.sh build` with no args falls back to the whole buildset. build_updated_arch now refuses an empty target list and points at build_updated, the entry point that computes the targets.

On top of that, machinery to turn the update flow into PRs, one per SOURCE-group:

- shvr_group_of maps a shell to its source via the existing versionsource hook, so ash+hush (one busybox tree) share a group -- and a PR, and a build -- while every other shell is its own group.
- shvr_updated_groups folds the updated targets into "<group> <shell...>" lines, one per group, reducing to distinct shells first so the variant is sourced once per shell rather than once per target. A shell's release and snapshot bumps land in the same group (one PR carries both).
- build_updated_arch gained an optional SHVR_BUILD_CACHE_FROM so CI can warm the toolchain from the committed registry cache instead of recompiling musl-cross-make in every job. Unset locally, so the local build is unchanged.

.github/workflows/update-prs.yml is dispatch-only for now: it runs update, plans the changed groups (empty shells filter = all of them, which is what a future cron run gets since workflow_dispatch inputs are absent then), and fans out over a group matrix throttled by max-parallel. Each group goes through the reusable update-group.yml, which builds both arches on native runners, prunes the group's dropped versions, and opens/refreshes ONE durable PR on branch update/<group> so re-runs never spam new PRs. A PR opened with the default GITHUB_TOKEN will not trigger the build workflow; set UPDATE_PR_TOKEN to a PAT to have update PRs run CI automatically.

This must produce both source and build checksums for both arches, because a new version has no committed build checksums and the assemble job fails closed on that; verified locally by running build_updated for dash end to end (source checksum + amd64/arm64 build checksums written, dropped 0.5.13.4 pruned).

Also de-hardcodes the dash pin in workflow-verification.yml: it resolved dash_0.5.13.4 literally, which the first dash bump this workflow lands would have stranded on a 404. It now resolves `current dash` at runtime.